### PR TITLE
Enforce teststream over teststreamloop

### DIFF
--- a/VHF/board_init/board.py
+++ b/VHF/board_init/board.py
@@ -272,7 +272,7 @@ class Board:
             try:
                 with TemporaryFile(dir="/dev/shm") as f:
                     output = subprocess.run(
-                        **(vhf_runner.subprocess_run(f)),
+                        **(vhf_runner.subprocess_run(f, timeout=1.8)),
                         stderr=subprocess.PIPE,
                     )
                     print(f"[Board.hybrid_clear] readout has len = {f.tell()}")
@@ -283,9 +283,12 @@ class Board:
                 self.logger.critical("%s", exc)
                 self.logger.critical("exc.stderr = ")
                 self.logger.critical("%s", exc.stderr)
+                return
             except subprocess.TimeoutExpired as exc:
                 self.logger.critical("TimeoutExpired with exception:")
                 self.logger.critical("%s", exc)
                 self.logger.critical("exc.stderr = ")
                 self.logger.critical("%s", exc.stderr)
+                self.logger.warn("Was a looping version of teststream used?")
+                return
             sleep(0.1)

--- a/VHF/runner.py
+++ b/VHF/runner.py
@@ -288,6 +288,8 @@ class VHFRunner():
             result.extend(['-F', self.board_kwargs['filter_const']])
         # other board params
         for k, v in self.board_kwargs.items():
+            if k in list(["vga_num", "filter_const"]):
+                continue
             result.extend(['-'+k, s(v)])
 
         return result

--- a/VHF/runner.py
+++ b/VHF/runner.py
@@ -16,6 +16,7 @@ from typing import Any
 from typing import IO
 from typing import Iterable
 from typing import Mapping
+from typing import Optional
 from typing import Union
 from .process import board_in_use
 
@@ -359,7 +360,7 @@ class VHFRunner():
         self.logger.debug("subprocess_Popen called. Returning %s", result)
         return result
 
-    def subprocess_run(self, stdout: _FILE = None) -> dict:
+    def subprocess_run(self, stdout: _FILE = None, timeout: Optional[float] = None) -> dict:
         """All arguments for subprocess.run(...).
 
         If writing to stdout instead, user is to provide their own pipe to pass
@@ -367,7 +368,10 @@ class VHFRunner():
         """
         result = self.subprocess_Popen()
         result["check"] = True
-        result["timeout"] = 7 + self.sample_time()
+        if float is None:
+            result["timeout"] = 7 + self.sample_time()
+        else:
+            result["timeout"] = timeout
 
         if self.to_file:
             result['capture_output'] = True


### PR DESCRIPTION
There is current ongoing work in having IOCTL not calling
`Start_USB_Machine` to generate a new file by editing teststream.c
(currently teststreamloop.c) to instead create the new file. As such,
clear_FIFO has some issues.

We enforce a lower timeout specifically on teststream alone,
(no runtime checks that the compiled executable does not have
looping behaviour); enforce correct attributes of teststream, and
fix a minor bug for filename generation.