### PR TITLE
Large sampling frequencies broke the parser

### DIFF
--- a/VHF/parse.py
+++ b/VHF/parse.py
@@ -7,7 +7,7 @@ import math
 import numpy as np
 from numpy.typing import NDArray
 import os
-from pandas import Timedelta
+from pandas import Timedelta, Timestamp
 
 __all__ = [
     "VHFparser",
@@ -88,8 +88,8 @@ class TraceTimer:
         """
         self.logger = logging.getLogger("vhfparser")
 
-        self.trace_start = trace_start
-        self.trace_duration = timedelta(seconds=trace_size/trace_freq)
+        self.trace_start = Timestamp(trace_start)
+        self.trace_duration = Timedelta(microseconds=1e6*trace_size/trace_freq)
         self.sample_interval = Timedelta(seconds=1/trace_freq)
         self.trace_end = self.trace_start + self.trace_duration
         self.trace_freq = trace_freq
@@ -243,7 +243,7 @@ class TraceTimer:
     def duration_idx(self) -> int:
         """Duration index of plot window specifying number of bytes to read."""
         delta = self.plot_end - self.plot_start
-        return int(int(delta/self.sample_interval))
+        return int(delta/self.sample_interval)
 
 
 class ManifoldRollover:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 tabulate
+numpy < 2.0
+pandas
 PyQt6
 PyGObject
 pytest

--- a/test/test_parseTraceTimer.py
+++ b/test/test_parseTraceTimer.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone, timedelta
 from logging import getLogger
 from multiprocessing.pool import Pool
+from pandas import Timedelta
 from pathlib import Path
 import pytest
 import sys
@@ -181,3 +182,15 @@ def test_TraceTimer_illegal_freq():
     example_size = example_freq * 2 * 60 * 60  # 2 hours
     with pytest.raises(ValueError) as e:
         timings = TraceTimer(example_start, example_freq, example_size)
+
+
+def test_TraceTimer_run_and_plot():
+    start = datetime.fromisoformat("2024-07-22 12:56:17+08:00")
+    freq = 2000000.0
+    size = 8413185
+    timings = TraceTimer(start, freq, size)
+    expected = Timedelta(seconds=size/freq)
+
+    assert timings.trace_end - start == expected
+    assert timings.start_idx == 0
+    assert timings.end_idx == size


### PR DESCRIPTION
We utilise panda's extension of standard library's datetime and timedelta,
namely Timestamp and Timedelta to represent the internal states of TraceTimer.
This should help resolve majority of precision issues from truncating past the
millisecond region.
We add some unit tests too.
