### PR TITLE
Archive Chirp Z transform for SAB (2024) plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ Archive/Miguel Spectrogram Recreation/Transfer
 !Archive/20230901 Threading Speed
 !Archive/20230902 Moment Record
 Archive/20230901 Threading Speed/test_Results
+
+# Include 2024SAB
+!Archive/20240720 SAB Figures

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,5 @@ Archive/20230901 Threading Speed/test_Results
 
 # Include 2024SAB
 !Archive/20240720 SAB Figures
+*.npz
+*.png

--- a/Archive/20240720 SAB Figures/Indiv_Spectrums.py
+++ b/Archive/20240720 SAB Figures/Indiv_Spectrums.py
@@ -1,0 +1,152 @@
+from datetime import datetime, timedelta
+from matplotlib import pyplot as plt
+from matplotlib.dates import DateFormatter, HourLocator, MinuteLocator
+from matplotlib.gridspec import GridSpec
+import numpy as np
+from pathlib import Path
+from scipy.signal import decimate
+import sys
+module_path = str(Path(__file__).parents[2])
+if module_path not in sys.path:
+    sys.path.append(module_path)
+from VHF.parse import VHFparser
+from VHF.spec.mlab import detrend_linear, cz_spectrogram_amplitude
+
+BASE_DIR = Path(__file__).parent
+NIGHT = Path("/mnt/nas-fibre-sensing/20231115_Cintech_Heterodyne_Phasemeter/2024-01-22T04:43:44.331093_laser_chip_ULN00238_laser_driver_M00435617_laser_curr_392.8mA_port_number_5.bin")
+DAY = Path("/mnt/nas-fibre-sensing/20231115_Cintech_Heterodyne_Phasemeter/2024-01-22T08:27:26.850997_laser_chip_ULN00238_laser_driver_M00435617_laser_curr_392.8mA_port_number_5.bin")
+NIGHT_START = datetime.fromisoformat(NIGHT_RAW:="20240122T06:00")
+# DAY_START = datetime(2024, 01, 22, 06, 00, 00)
+DAY_START = datetime.fromisoformat(DAY_RAW:="20240122T09:00")
+INTERVAL = timedelta(seconds=15*60)
+FIG_WIDTH = 0.5*(8.3-2*0.6-0.1)
+NIGHT_PHASE_P = VHFparser(NIGHT, headers_only=True)
+NIGHT_PHASE_P.update_plot_timing(lazy=True, start=NIGHT_START, duration=INTERVAL)
+NIGHT_PHASE = NIGHT_PHASE_P.reduced_phase
+DAY_PHASE_P = VHFparser(DAY, headers_only=True)
+DAY_PHASE_P.update_plot_timing(lazy=True, start=DAY_START, duration=INTERVAL)
+DAY_PHASE = DAY_PHASE_P.reduced_phase
+
+def phase():
+    fig, [night, day] = plt.subplots(figsize=(FIG_WIDTH, 0.6*FIG_WIDTH), nrows=2, dpi=300, sharex=True)
+    night.tick_params(labelbottom=False)
+    night.tick_params(axis='both', which='major', labelsize=6)
+    night.tick_params(axis='both', which='minor', labelsize=6)
+    day.tick_params(axis='both', which='major', labelsize=6)
+    day.tick_params(axis='both', which='minor', labelsize=6)
+
+    # night_t = np.arange(NIGHT_START.isoformat(),
+    #                     (NIGHT_START+INTERVAL).isoformat(),
+    #                     np.timedelta64(INTERVAL/len(NIGHT_PHASE)),
+    #                     dtype='datetime64[s]')
+    # day_t = np.arange(DAY_START.isoformat(),
+    #                   (DAY_START+INTERVAL).isoformat(),
+    #                   np.timedelta64(INTERVAL*1000/len(DAY_PHASE)),
+    #                   dtype='datetime64[s]')
+    night_t = np.arange(len(NIGHT_PHASE)) / NIGHT_PHASE_P.header["sampling freq"] /60
+    day_t = np.arange(len(DAY_PHASE)) / DAY_PHASE_P.header["sampling freq"] /60
+
+    print(f"{night_t.shape = }, {NIGHT_PHASE.shape = }")
+    night.plot(night_t, NIGHT_PHASE, linewidth=0.2)
+    day.plot(day_t, DAY_PHASE, linewidth=0.2)
+    for ax in [night, day]:
+        ax.set_ylabel(r"$\phi_d$/2$\pi$ rad", usetex=True, fontsize=6)
+    #     ax.xaxis.set_major_locator(MinuteLocator(interval=5))
+    #     ax.xaxis.set_major_formatter(DateFormatter("%H:%M"))
+    # fig.autofmt_xdate()
+    day.set_xlabel(r"$t$/mins", usetex=True, fontsize=6)
+    fig.tight_layout(pad=1.01)
+    fig.subplots_adjust(hspace=0.02)
+    fig.savefig(BASE_DIR.joinpath("INDIV_PHASE.png"))
+
+def specgram():
+    """Side by side spectrograms comparing day and night coloring."""
+    sparse_num_phase = 5
+    sparse_num_velocity = 10
+    sparse_phase_factor = sparse_num_phase
+    sparse_velocity_factor = sparse_num_velocity
+
+    day_phase_decimated = decimate(DAY_PHASE, sparse_phase_factor, ftype="fir")
+    day_phase_avg_decimated = decimate(day_phase_decimated, sparse_velocity_factor, ftype="fir")
+    night_phase_decimated = decimate(NIGHT_PHASE, sparse_phase_factor, ftype="fir")
+    night_phase_avg_decimated = decimate(night_phase_decimated, sparse_velocity_factor, ftype="fir")
+
+    daySxx, f, t, day_ax_extent = cz_spectrogram_amplitude(
+        signal=day_phase_avg_decimated,
+        fn=(2,31),
+        samp_rate=DAY_PHASE_P.header['sampling freq']/(sparse_velocity_factor*sparse_phase_factor),
+        # wlen=parsed1.header['sampling freq']/100,
+        win_s = 6.0,
+        p_overlap=0.90,  # Following miguel's default
+        detrend_func=detrend_linear,
+    )
+    day_ax_extent = extent_in_mins(day_ax_extent)
+    print(f"{np.max(daySxx) = }")
+    nightSxx, f, t, night_ax_extent = cz_spectrogram_amplitude(
+        signal=night_phase_avg_decimated,
+        fn=(2,31),
+        samp_rate=NIGHT_PHASE_P.header['sampling freq']/(sparse_velocity_factor*sparse_phase_factor),
+        # wlen=parsed1.header['sampling freq']/100,
+        win_s = 6.0,
+        p_overlap=0.90,  # Following miguel's default
+        detrend_func=detrend_linear,
+    )
+    night_ax_extent = extent_in_mins(night_ax_extent)
+    print(f"{np.max(nightSxx) = }")
+    print(f"{night_ax_extent = }")
+
+    fig = plt.figure(figsize=(FIG_WIDTH, 0.6*FIG_WIDTH), dpi=300)
+    gs = GridSpec(
+        nrows=1, ncols=3,
+        figure=fig,
+        wspace=0.1,
+        # height_ratios=[2, 3],
+        width_ratios=[1, 1, .03]
+    )
+    night = plt.subplot(gs[0])
+    day = plt.subplot(gs[1], sharey=night)
+    colb = plt.subplot(gs[2])
+
+    night.tick_params(axis='both', which='major', labelsize=6)
+    night.tick_params(axis='both', which='minor', labelsize=0)
+    day.tick_params(axis='both', which='major', labelsize=6)
+    day.tick_params(axis='both', which='minor', labelsize=0)
+    day.tick_params(labelleft=False)
+    cmap = night.imshow(
+        nightSxx,
+        vmax=2,
+        cmap="gray_r",
+        **night_ax_extent
+    )
+    day.imshow(
+        daySxx,
+        vmax=2,
+        cmap="gray_r",
+        **day_ax_extent
+    )
+    plt.colorbar(cmap, cax=colb, shrink=1.0, extend="max")
+    night.set_ylabel(r"$f$/Hz", usetex=True, fontsize=6)
+    night.set_xlabel(r"$t$/mins", usetex=True, fontsize=6)
+    day.set_xlabel(r"$t$/mins", usetex=True, fontsize=6)
+    colb.set_ylabel(r"Amplitude Spectrum Density $\Delta\lambda/\sqrt{\text{Hz}}$", fontsize=6)
+    colb.tick_params(axis='both', which='major', labelsize=6)
+    # fig.subplots_adjust(wspace=0.04)
+    fig.subplots_adjust(left=0.115, bottom=0.165, right=0.850, top=0.945, wspace=0.04)
+    fig.savefig(BASE_DIR.joinpath("INDIV_SPEC.png"))
+
+def extent_in_mins(ex: dict):
+    extent = ex["extent"]
+    extent = (extent[0]/60, extent[1]/60, *extent[2:])
+    ex["extent"] = extent
+    return ex
+
+
+def main():
+    phase()
+    specgram()
+
+    return
+
+
+if __name__ == "__main__":
+    main()

--- a/Archive/20240720 SAB Figures/SAB_plots.py
+++ b/Archive/20240720 SAB Figures/SAB_plots.py
@@ -1,6 +1,5 @@
-from datetime import date
-import datetime
-import datetime as dt
+from datetime import date, datetime, timedelta
+from data_to_npy import aware_to_naive
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.dates import DateFormatter
@@ -10,6 +9,8 @@ import numpy as np
 from numpy import datetime64
 from pathlib import Path
 
+ARBITRARY_DAY = date(1970, 1, 1)
+ARBITRARY_DATETIME = datetime(1970, 1, 1)
 BASE_DIR = Path(__file__).parent
 NPZ_FILE = BASE_DIR.joinpath("./SAB_Collated_JanData.npz")
 FREQ_IDX = 600
@@ -50,8 +51,8 @@ def plot_data():
 
 
 def is_day(day: date):
-    def func(t: datetime64):
-        t = t.astype('datetime64[D]')
+    def func(x: list[datetime]):
+        t = np.fromiter(map(aware_to_naive, x), dtype='datetime64[D]')
         t_year = t.astype('datetime64[Y]').astype(int) + 1970
         t_month =  t.astype('datetime64[M]').astype(int) % 12 + 1
         t_date = t - t.astype('datetime64[M]') + 1
@@ -87,8 +88,7 @@ def extract_time_as_datetime_from_NDarr_of_npdatetime64_w_dtype_obj(x):
     To ensure a cleaner plot we set all object to having the same date, so that
     matplotlib doesn't extend the x-axis for showing 4 days.
     """
-    arbitrary_day = datetime.date(1970, 1, 1)
-    return list(map(lambda y: datetime.datetime.combine(arbitrary_day, y.time()), x))
+    return list(map(lambda y: datetime.combine(ARBITRARY_DAY, y.time()), x))
 
 
 def main(err_bars: bool = False):
@@ -148,19 +148,14 @@ def main(err_bars: bool = False):
             )
 
         # a. set x_axis
-        # ax.xaxis.set_major_formatter(DateFormatter('%H:%M'))
-        # ax.yaxis.set_major_formatter(mticker.ScalarFormatter())
-        # ax.yaxis.set_minor_formatter(mticker.ScalarFormatter())
-        # ax.yaxis.set_major_formatter(mticker.StrMethodFormatter("{x:.2f}"))
-        # ax.yaxis.set_minor_formatter(mticker.StrMethodFormatter("{x:.2f}"))
         dfmt = mdates.DateFormatter("%-I%P")
-        plt.xlim(dt.datetime(1970,1,1), dt.datetime(1970,1,2))
+        plt.xlim(ARBITRARY_DATETIME, ARBITRARY_DATETIME+timedelta(hours=24))
         plt.xticks([
-            dt.datetime(1970, 1, 1, 0),
-            dt.datetime(1970, 1, 1, 6),
-            dt.datetime(1970, 1, 1, 12),
-            dt.datetime(1970, 1, 1, 18),
-            dt.datetime(1970, 1, 2),
+            datetime(1970, 1, 1, 0),
+            datetime(1970, 1, 1, 6),
+            datetime(1970, 1, 1, 12),
+            datetime(1970, 1, 1, 18),
+            datetime(1970, 1, 2),
         ])
         ax.xaxis.set_major_formatter(dfmt)
         plt.legend(["Friday", "Saturday", "Sunday", "Monday"], loc="lower right", prop={"size":8}, ncol=2)

--- a/Archive/20240720 SAB Figures/SAB_plots.py
+++ b/Archive/20240720 SAB Figures/SAB_plots.py
@@ -1,0 +1,252 @@
+from datetime import date
+import datetime
+import datetime as dt
+from matplotlib import pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.dates import DateFormatter
+import matplotlib.dates as mdates
+import matplotlib.ticker as mticker
+import numpy as np
+from numpy import datetime64
+from pandas import Timestamp
+from pathlib import Path
+
+BASE_DIR = Path(__file__).parent
+NPZ_FILE = BASE_DIR.joinpath("./SAB_Collated_JanData.npz")
+FREQ_IDX = 600
+FREQ_UNDER_PLOT = 15.715925744992672
+
+def plot_data():
+    """time, amplitude(linear, Δλ/√Hz), error for plot"""
+
+    # 1. Pull from files
+    with open(NPZ_FILE, "rb+") as file:
+        npz = np.load(file, allow_pickle=True)
+        times = npz["times"]
+        freqs = npz["freqs"]
+        ampls = npz["ampls"]
+        times = times.flatten()
+
+    # if times is None or freqs is None or ampls is None:
+    #     raise ValueError
+
+    # 1a. Ensure we pulled the correct data
+    assert times.shape == (344,)
+    assert freqs[0, FREQ_IDX] == FREQ_UNDER_PLOT
+
+    # 2. Clean data up into matplotlib friendlier terms
+    mean, std = ampls[:, 0, FREQ_IDX],  ampls[:, 1, FREQ_IDX]
+    times = np.fromiter(map(
+        lambda x: x.tz_localize(None).to_datetime64(), times
+    ), dtype=object)
+    lower = np.power(10, (mean-std)/20)
+    upper = np.power(10, (mean+std)/20)
+    mean = np.power(10, mean/20)
+    err = np.vstack((mean-lower, upper-mean))
+
+    # 3. sort in time
+    idx_sort = np.argsort(times)
+    times = times[idx_sort]
+    mean = mean[idx_sort]
+    err = err[:, idx_sort]
+    print(f"{type(times[0]) = }")
+    return times, mean, err
+
+
+def is_day(day: date):
+    def func(t: datetime64):
+        t = t.astype('datetime64[D]')
+        t_year = t.astype('datetime64[Y]').astype(int) + 1970
+        t_month =  t.astype('datetime64[M]').astype(int) % 12 + 1
+        t_date = t - t.astype('datetime64[M]') + 1
+        t_date = t_date.astype('int')
+
+        return np.logical_and(
+            np.logical_and(t_date == day.day, t_month == day.month),
+            t_year == day.year
+        )
+    return func
+
+
+def fig_size_etc(case: str):
+    """Choose between SAB and QE and Indiv."""
+    match case:
+        case "SAB":
+            return (5, 3), 12, 3, 2, 4
+        case "QE":
+            inches_per_mm = 0.0393
+            scale_factor = 0.75
+            return (scale_factor*160*inches_per_mm, 0.8*scale_factor*90*inches_per_mm), 10, 4, 2, 3
+        case "Indiv":
+            # This did not go into the SAB-Individual poster component in the end.
+            scale_factor = 0.5
+            return ((x_in:=0.5*(11.7-2*0.6-0.1)), scale_factor*x_in), 10, 4, 2, 3
+        case _:
+            raise ValueError
+
+
+def extract_time_as_datetime_from_NDarr_of_npdatetime64_w_dtype_obj(x):
+    x = np.fromiter(map(Timestamp, x), dtype=Timestamp)
+    x = np.fromiter(map(lambda y: y.to_pydatetime(), x), dtype=datetime.datetime)
+    arbitrary_day = datetime.date(1970, 1, 1)
+    return np.fromiter(
+        map(lambda y: datetime.datetime.combine(arbitrary_day, y.time()), x),
+        dtype=datetime.time
+    )
+
+
+def main(err_bars: bool = False):
+    """Plot of average Sxx(@15.7Hz) of every 15 mins over 4 days."""
+    # 1. Get data for plotting
+    times, mean, err = plot_data()
+
+    # 2. Get plot parameters
+    for plot_type in ["SAB", "QE", "Indiv"]:
+        fig_size, font_size, msize, elinew, csize = fig_size_etc(plot_type)
+
+        # 3. Perform plotting; We have the spectrogram in a separate figure
+        # 3a. Set figure up
+        fig, ax = plt.subplots(figsize=fig_size, dpi=300)
+        for day_offset in range(4):
+            current_day = date(year=2024, month=1, day=19+day_offset)
+            if not err_bars:  # There are no error bars
+                target_y_lim = (10**-0.98, 10**-0.72)
+                err = np.zeros_like(err)
+            else:  # There are error bars
+                target_y_lim = (10**-2.0, 10**-0.0)
+                ax.set_yscale("log")
+            ax.set_ylim(*target_y_lim)
+            idx = np.where(is_day(current_day)(times))
+            # 3b. Perform error plot
+            f_err = err[:, idx]  # filtered err
+            times_after_offset = times[idx]
+            times_after_offset = extract_time_as_datetime_from_NDarr_of_npdatetime64_w_dtype_obj(times_after_offset)
+
+            ys = mean[idx]
+            if day_offset == 3:
+                cutoff = 9
+                times_after_offset = times_after_offset[:-cutoff]
+                ys = ys[:-cutoff]
+                f_err = f_err[:, :, :-cutoff]
+            ax.plot(
+                times_after_offset, ys,
+                "-x",
+                linewidth=0.5,
+                markersize=msize,
+            )
+            if err_bars:
+                ax.errorbar(
+                    times_after_offset, ys,
+                    yerr=f_err.reshape(-1, *f_err.shape[-1:]),
+                    fmt=".",
+                    markersize=msize,
+                    elinewidth=elinew,
+                    capsize=csize
+                )
+            # 3c. y-axis names
+            ax.set_ylabel(
+                r"Amplitude ($\Delta\lambda / \sqrt{\text{Hz}}$)",
+                # r"Amplitude $\left[\Delta\lambda/\sqrt{\text{Hz}}\right]$",
+                # usetex=True,
+                fontsize=font_size
+            )
+
+        # a. set x_axis
+        # ax.xaxis.set_major_formatter(DateFormatter('%H:%M'))
+        # ax.yaxis.set_major_formatter(mticker.ScalarFormatter())
+        # ax.yaxis.set_minor_formatter(mticker.ScalarFormatter())
+        # ax.yaxis.set_major_formatter(mticker.StrMethodFormatter("{x:.2f}"))
+        # ax.yaxis.set_minor_formatter(mticker.StrMethodFormatter("{x:.2f}"))
+        dfmt = mdates.DateFormatter("%-I%P")
+        plt.xlim(dt.datetime(1970,1,1), dt.datetime(1970,1,2))
+        plt.xticks([
+            dt.datetime(1970, 1, 1, 0),
+            dt.datetime(1970, 1, 1, 6),
+            dt.datetime(1970, 1, 1, 12),
+            dt.datetime(1970, 1, 1, 18),
+            dt.datetime(1970, 1, 2),
+        ])
+        ax.xaxis.set_major_formatter(dfmt)
+        plt.legend(["Friday", "Saturday", "Sunday", "Monday"], loc="lower right", prop={"size":8}, ncol=2)
+        plt.tight_layout()
+        # b. Other titling
+        # fig.suptitle(r"Spectrum observed over 4 days")
+
+        if err_bars:
+            err_name = "_wErr"
+        else:
+            err_name = ""
+        # plt.show()
+        fig.savefig(BASE_DIR.joinpath(f"{plot_type}_{FREQ_UNDER_PLOT:.5f}Hz_Jan{err_name}.png"), dpi=300)
+        # 4. Close figure
+        plt.close()
+
+    return
+
+
+def qe_plot_data():
+    """For data point of 2024Jan22, get (mean,err) against frequencies."""
+    # 1. Pull from files
+    with open(NPZ_FILE, "rb+") as file:
+        npz = np.load(file, allow_pickle=True)
+        times = npz["times"]
+        freqs = npz["freqs"]
+        ampls = npz["ampls"]
+        times = times.flatten()
+
+    # if times is None or freqs is None or ampls is None:
+    #     raise ValueError
+
+    # 1a. Ensure we pulled the correct data
+    assert times.shape == (344,)
+    assert freqs[0, FREQ_IDX] == FREQ_UNDER_PLOT
+
+    # 2. Clean data up into matplotlib friendlier terms
+    times = np.fromiter(map(
+        lambda x: x.tz_localize(None).to_datetime64(), times
+    ), dtype=object)
+    # 3. sort in time
+    idx_sort = np.argsort(times)
+    times = times[idx_sort]
+
+    time_idx = -39
+    times = times[time_idx]
+    freqs = freqs[time_idx]
+    mean, std = ampls[time_idx, 0, :],  ampls[time_idx, 1, :]
+    lower = np.power(10, (mean-std)/20)
+    upper = np.power(10, (mean+std)/20)
+    mean = np.power(10, mean/20)
+    err = np.vstack((mean-lower, upper-mean))
+
+    print(f"{times = }")
+    return freqs, mean, err
+
+
+def qe_plot_main():
+    """Plot for a single time point (2024Jan22) across all frequencies."""
+    freqs, mean, err = qe_plot_data()
+    fig_size, font_size, msize, elinew, csize = fig_size_etc("Indiv")
+
+    fig, p_ampx = plt.subplots(figsize=fig_size, dpi=300)
+    p_ampx.set_yscale("log")
+    p_ampx.plot(freqs, mean)
+    p_ampx.fill_between(freqs, mean-err[0], mean+err[1],
+                        alpha=0.5)
+    p_ampx.set_title("22 Jan 2024 6.00-6.15am")
+    p_ampx.set_ylabel(
+        r"Amplitude ($\Delta\lambda / \sqrt{\text{Hz}}$)",
+        fontsize=font_size
+    )
+    p_ampx.set_xlabel(
+        r"Freq (Hz)",
+        fontsize=font_size
+    )
+    fig.tight_layout(pad=1.01)
+    fig.savefig(BASE_DIR.joinpath("Indiv_freq.png"), dpi=300)
+
+
+if __name__ == "__main__":
+    main(True)
+    main()
+    print("Sxx over freq plot!")
+    qe_plot_main()

--- a/Archive/20240720 SAB Figures/SAB_plots.py
+++ b/Archive/20240720 SAB Figures/SAB_plots.py
@@ -8,7 +8,6 @@ import matplotlib.dates as mdates
 import matplotlib.ticker as mticker
 import numpy as np
 from numpy import datetime64
-from pandas import Timestamp
 from pathlib import Path
 
 BASE_DIR = Path(__file__).parent
@@ -36,9 +35,6 @@ def plot_data():
 
     # 2. Clean data up into matplotlib friendlier terms
     mean, std = ampls[:, 0, FREQ_IDX],  ampls[:, 1, FREQ_IDX]
-    times = np.fromiter(map(
-        lambda x: x.tz_localize(None).to_datetime64(), times
-    ), dtype=object)
     lower = np.power(10, (mean-std)/20)
     upper = np.power(10, (mean+std)/20)
     mean = np.power(10, mean/20)
@@ -86,13 +82,13 @@ def fig_size_etc(case: str):
 
 
 def extract_time_as_datetime_from_NDarr_of_npdatetime64_w_dtype_obj(x):
-    x = np.fromiter(map(Timestamp, x), dtype=Timestamp)
-    x = np.fromiter(map(lambda y: y.to_pydatetime(), x), dtype=datetime.datetime)
+    """Matplotlib requires that the x-axis be datetime and not time objects.
+    We are filtering down from what is an NDArray of datetime64.
+    To ensure a cleaner plot we set all object to having the same date, so that
+    matplotlib doesn't extend the x-axis for showing 4 days.
+    """
     arbitrary_day = datetime.date(1970, 1, 1)
-    return np.fromiter(
-        map(lambda y: datetime.datetime.combine(arbitrary_day, y.time()), x),
-        dtype=datetime.time
-    )
+    return list(map(lambda y: datetime.datetime.combine(arbitrary_day, y.time()), x))
 
 
 def main(err_bars: bool = False):
@@ -202,9 +198,8 @@ def qe_plot_data():
     assert freqs[0, FREQ_IDX] == FREQ_UNDER_PLOT
 
     # 2. Clean data up into matplotlib friendlier terms
-    times = np.fromiter(map(
-        lambda x: x.tz_localize(None).to_datetime64(), times
-    ), dtype=object)
+    # there is nothing
+    
     # 3. sort in time
     idx_sort = np.argsort(times)
     times = times[idx_sort]

--- a/Archive/20240720 SAB Figures/data_to_npy.py
+++ b/Archive/20240720 SAB Figures/data_to_npy.py
@@ -10,6 +10,7 @@ from numpy.typing import NDArray
 from pathlib import Path
 from scipy.signal import decimate
 import sys
+from typing import Iterable
 module_path = str(Path(__file__).parents[2])
 if module_path not in sys.path:
     sys.path.append(module_path)
@@ -38,6 +39,7 @@ def init_pool_processes(the_lock):
 
 def worker(args):
     """Currently, we demand that workers can only take 1 arg for imap."""
+    logger.info("worker called with args: %s", args)
     return averaging_spectrogram(args)
 
 @cache
@@ -48,41 +50,40 @@ def trace_endpoints(file) -> tuple[datetime, datetime]:
     end_time: datetime = p.timings.trace_end
     return (start_time, end_time)
 
-def get_bin_files(time: np.datetime64) -> list[Path]:
+def get_bin_files(time: datetime) -> list[Path]:
     """Obtain set of files to iterate over for time to time+interval.
 
     Files are included iff the provided timing is at least half of the desired
     interval.
     """
 
-    def time_is_located_within_file_endpoints(time: np.datetime64, file):
-        start_time, end_time = map(datetime64, map(aware_to_naive, trace_endpoints(file)))
+    def time_is_located_within_file_endpoints(time: datetime, file):
+        start_time, end_time = map(aware_to_naive, trace_endpoints(file))
         return start_time <= time and time <= end_time
 
     start_side = list(filter(lambda x: time_is_located_within_file_endpoints(time, x), FILES))
-    end_side = list(filter(lambda x: time_is_located_within_file_endpoints(time+timedelta64(INTERVAL), x), FILES))
+    end_side = list(filter(lambda x: time_is_located_within_file_endpoints(time + INTERVAL, x), FILES))
     result: list[Path] = start_side
     result.extend(end_side)
     result: set[Path] = set(result)
     if len(result) == 0 or len(result) > 2:
-        logger.warn(f"No file found for {time=}. {len(result)=}")
+        logger.warning("No file found for time=%s. {len(result)=%s}", time, len(result))
         pass
     if len(result) == 1:
         start, end = trace_endpoints(min(result))  # stupid way to access set item without pop
-
-        start, end = map(datetime64, map(aware_to_naive, [start, end]))
+        start, end = map(aware_to_naive, [start, end])
         # pop if overlap is less than helf
-        if start <= time + timedelta64(INTERVAL) <= end:
-            if start - time > timedelta64(INTERVAL)/2:
+        if start <= time + INTERVAL <= end:
+            if start - time > INTERVAL/2:
                 result.pop
         elif start <= time <= end:
-            if end - time < timedelta64(INTERVAL)/2:
+            if end - time < INTERVAL/2:
                 result.pop
 
     return sorted(list(result))
 
 
-def averaging_spectrogram(time: np.datetime64):
+def averaging_spectrogram(time: datetime):
     """We get the spectrogram for (time, time+INTERVAL), and save into npy file."""
     files = get_bin_files(time)
     logger.debug("Proc %s got files = %s", current_proc().name, map(lambda x: x.name, files))
@@ -93,7 +94,7 @@ def averaging_spectrogram(time: np.datetime64):
     p_freq_old = None
     p_freq = None
 
-    iteration_end = time + timedelta64(INTERVAL)
+    iteration_end = time + INTERVAL
     current_file = files.pop(0)
     parse = VHFparser(current_file, headers_only=True)
     current_file_start = parse.timings.trace_start
@@ -106,12 +107,12 @@ def averaging_spectrogram(time: np.datetime64):
     while plot_start < iteration_end and current_file is not None:
         plot_start = max(
             plot_start,
-            datetime64(aware_to_naive(current_file_start+timedelta(seconds=1)))
+            aware_to_naive(current_file_start+timedelta(seconds=1))
         )  # clamp to at least the first second after any trace
-        plot_end = plot_start + timedelta64(SPECGRAM_TOTAL_WINDOW)
+        plot_end = plot_start + SPECGRAM_TOTAL_WINDOW
         parse.update_plot_timing(
-            start=datetime(plot_start, tzinfo=timedelta(hours=8)),  # fails
-            end=datetime(plot_end, tzinfo=timedelta(hours=8))
+            start=plot_start.astimezone(tz=timezone(timedelta(hours=8))),
+            end=plot_end.astimezone(tz=timezone(timedelta(hours=8)))
         )
         phase = parse.reduced_phase
         freq = parse.header["sampling freq"]
@@ -151,7 +152,7 @@ def averaging_spectrogram(time: np.datetime64):
         # second addition is to move forward by one p-overlap
         plot_start = plot_end - 0.9*timedelta(seconds=SPECGRAM_WINDOW)
         logger.debug("Proc %s moving onto the next iteration of spectrogram window", current_proc().name)
-        if plot_start > current_file_end:
+        if plot_start > aware_to_naive(current_file_end):
             logger.debug("Proc %s attempting to fetch next file", current_proc().name)
             if len(files) == 0:
                 current_file = None
@@ -182,7 +183,7 @@ def averaging_spectrogram(time: np.datetime64):
     logger.debug("Proc %s moving onto next timer!", current_proc().name)
     return
 
-def averaging_spectrogram_write(time, freqs: NDArray, avgSxx: NDArray):
+def averaging_spectrogram_write(time: datetime, freqs: NDArray, avgSxx: NDArray):
     """Takes the data pulled out from the files for specified time and writes into npy file."""
     try:
         with lock:
@@ -225,11 +226,11 @@ def averaging_spectrogram_write_core(time, freqs: NDArray, avgSxx: NDArray):
 def main():
     """Perform digesting of files down into averaged spectrograms."""
     print(f"We are now running for {len(SEARCH_FILES) = }")
-    timings: NDArray[np.datetime64] = timings_left()
+    timings: Iterable[datetime] = timings_left()
     random.shuffle(timings)
 
     npz_lock = Lock()
-    with Pool(cpu_count()-2, initializer=init_pool_processes, initargs=(npz_lock,)) as pool:
+    with Pool(cpu_count()-1, initializer=init_pool_processes, initargs=(npz_lock,)) as pool:
         p = pool.imap_unordered(
             worker,
             # pair_lock_with_time(timings, mutex_lock)
@@ -240,7 +241,9 @@ def main():
 def main_linear():
     """Perform digesting of files down into averaged spectrograms without Pool."""
     print(f"We are now running for {len(SEARCH_FILES) = }")
-    timings: NDArray[np.datetime64] = timings_left()
+    timings: Iterable[datetime] = timings_left()
+    random.shuffle(timings)
+
     lock = Lock()
     for t in timings:
         worker(t)
@@ -260,7 +263,12 @@ def aware_to_naive(t: datetime) -> datetime:
     return result.replace(tzinfo=None)
 
 
-def timings_left() -> NDArray[np.datetime64]:
+def datetime64_to_dt(t: np.datetime64) -> datetime:
+    """Takes a numpy datetime64 and give a naive python datetime."""
+    return datetime.strptime(t.astype(str)[:-3], '%Y-%m-%dT%H:%M:%S.%f')
+
+
+def timings_left() -> list[datetime]:
     """Array of time-axis data points still needed."""
     # np.arange will preferably generate np.datetime64 from TIME_START: datetime.datetime
     # this will consequently cast from TZ+X to TZ+0.
@@ -282,7 +290,8 @@ def timings_left() -> NDArray[np.datetime64]:
     except ValueError:
         logger.debug("Nothing from file")
     only_in_timings = np.setdiff1d(timings, times_arr)
-    logger.debug("Remaining times found needed doing: only_in_timings = %s", only_in_timings)
+    only_in_timings = list(map(datetime64_to_dt, only_in_timings))  # putting this in an NDArray only undoes our work
+    logger.info("Remaining times found needed doing: only_in_timings = %s", only_in_timings)
     return only_in_timings
 
 

--- a/Archive/20240720 SAB Figures/data_to_npy.py
+++ b/Archive/20240720 SAB Figures/data_to_npy.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import datetime, timedelta, timezone, tzinfo
 from functools import cache, partial
 import logging
@@ -100,6 +101,7 @@ def get_parsed(managed_list: DictProxy, name: Path):
         logger.debug("result.plot_window = %s", result.timings.plot_start)
         if result.timings.plot_start - result.timings.trace_start > timedelta(seconds=6):
             logger.warning("plot_start much larger than trace_start! trace_start = %s", result.timings.trace_start)
+    result = deepcopy(result)
     return result
 
 

--- a/Archive/20240720 SAB Figures/data_to_npy.py
+++ b/Archive/20240720 SAB Figures/data_to_npy.py
@@ -62,7 +62,7 @@ def get_bin_files(time: datetime) -> list[Path]:
     """
 
     def time_is_located_within_file_endpoints(time: datetime, file):
-        start_time, end_time = map(aware_to_naive, trace_endpoints(file))
+        start_time, end_time = trace_endpoints(file)
         return start_time <= time and time <= end_time
 
     start_side = list(filter(lambda x: time_is_located_within_file_endpoints(time, x), FILES))
@@ -75,7 +75,6 @@ def get_bin_files(time: datetime) -> list[Path]:
         pass
     if len(result) == 1:
         start, end = trace_endpoints(min(result))  # stupid way to access set item without pop
-        start, end = map(aware_to_naive, [start, end])
         # pop if overlap is less than helf
         if start <= time + INTERVAL <= end:
             if start - time > INTERVAL/2:
@@ -129,12 +128,12 @@ def averaging_spectrogram(managed_list: DictProxy, time: datetime):
     while plot_start < iteration_end and current_file is not None:
         plot_start = max(
             plot_start,
-            aware_to_naive(current_file_start+timedelta(seconds=1))
+            current_file_start+timedelta(seconds=1)
         )  # clamp to at least the first second after any trace
         plot_end = plot_start + SPECGRAM_TOTAL_WINDOW
         parse.update_plot_timing(
-            start=plot_start.astimezone(tz=timezone(timedelta(hours=8))),
-            end=plot_end.astimezone(tz=timezone(timedelta(hours=8)))
+            start=plot_start,
+            end=plot_end
         )
         phase = parse.reduced_phase
         freq = parse.header["sampling freq"]
@@ -174,7 +173,7 @@ def averaging_spectrogram(managed_list: DictProxy, time: datetime):
         # second addition is to move forward by one p-overlap
         plot_start = plot_end - 0.9*timedelta(seconds=SPECGRAM_WINDOW)
         logger.debug("Proc %s moving onto the next iteration of spectrogram window", current_proc().name)
-        if plot_start > aware_to_naive(current_file_end):
+        if plot_start > current_file_end:
             logger.debug("Proc %s attempting to fetch next file", current_proc().name)
             if len(files) == 0:
                 current_file = None
@@ -204,6 +203,7 @@ def averaging_spectrogram(managed_list: DictProxy, time: datetime):
     averaging_spectrogram_write(time, freqs, avgSxx)
     logger.debug("Proc %s moving onto next timer!", current_proc().name)
     return
+
 
 def averaging_spectrogram_write(time: datetime, freqs: NDArray, avgSxx: NDArray):
     """Takes the data pulled out from the files for specified time and writes into npy file."""
@@ -245,6 +245,7 @@ def averaging_spectrogram_write_core(time, freqs: NDArray, avgSxx: NDArray):
         np.savez(file, times=times_arr, freqs=freqs_arr, ampls=ampls_arr)
         logger.info("%s Save done", current_proc().name)
 
+
 def main():
     """Perform digesting of files down into averaged spectrograms."""
     print(f"We are now running for {len(SEARCH_FILES) = }")
@@ -266,6 +267,7 @@ def main():
         y = list(p)  # we need something to iteratively consume up the imap to drive the pool
 
     global_cm.shutdown()
+
 
 def main_linear():
     """Perform digesting of files down into averaged spectrograms without Pool."""
@@ -291,6 +293,11 @@ def aware_to_naive(t: datetime) -> datetime:
         offset = timedelta(hours=0)
     result = t.astimezone(timezone(timedelta(hours=0))) + offset
     return result.replace(tzinfo=None)
+
+
+def naive_to_aware(t: datetime, h:int=8) -> datetime:
+    """Replace tzinfo to be aware."""
+    return t.astimezone(timezone(timedelta(hours=h)))
 
 
 def datetime64_to_dt(t: np.datetime64) -> datetime:
@@ -320,7 +327,9 @@ def timings_left() -> list[datetime]:
     except ValueError:
         logger.debug("Nothing from file")
     only_in_timings = np.setdiff1d(timings, times_arr)
-    only_in_timings = list(map(datetime64_to_dt, only_in_timings))  # putting this in an NDArray only undoes our work
+    only_in_timings = map(datetime64_to_dt, only_in_timings)  # putting this in an NDArray only undoes our work
+    only_in_timings = map(naive_to_aware, only_in_timings) 
+    only_in_timings = list(only_in_timings)
     logger.info("Remaining times found needed doing: only_in_timings = %s", only_in_timings)
     return only_in_timings
 


### PR DESCRIPTION
# Context of Work
With the provisioned online variance algorithm along with Chirp Z transformation ontop of plot-views into the VHF data, it is now feasible to perform analysis of VHF data over an artificially narrower window of frequency space for large amounts of days (shown in `data_to_npy.py`).
The correspondingly generated npz data files are handled in `SAB_plots.py`.

# Context of Branch
This branch has always been based on the "spectrogram_works" branch (which created the Chirp Z transformation and rolling variance library functions), but "spectrogram_works" was rebased from 0.5.0.2 to 0.5.1; and so the commit in the middle accounts for the move away from Panda's Timestamp type.

## Technical details
Please refer to individual commit messages.