### PR TITLE
Add stdout for v1-filetype

### DIFF
--- a/VHF-rs/src/bin/stream.rs
+++ b/VHF-rs/src/bin/stream.rs
@@ -5,7 +5,7 @@ use std::sync::mpsc::{Receiver, channel};
 use std::thread;
 use vhf::runner::{
     Config, VHF,
-    fold::StreamFold,
+    fold::StreamFoldOp,
     writer::{V1Writer, VHFWriter, WriteBlock},
 };
 use vhf::{Error, Result};
@@ -45,10 +45,7 @@ fn main() -> Result<()> {
     let time_start = vhf.start()?;
 
     let file_writer = V1Writer::new(&conf, time_start);
-    let StreamFold::Map(params) = params else {
-        log::error!("Overlapping windows are not StreamFold::Map variant.");
-        panic!()
-    };
+    matches!(params.op, StreamFoldOp::Map);
 
     let (writer_send, writer_receive) = channel();
     let writer_thread = thread::Builder::new()

--- a/VHF-rs/src/bin/stream.rs
+++ b/VHF-rs/src/bin/stream.rs
@@ -1,13 +1,11 @@
+use jiff::Zoned;
 use pariter::IteratorExt;
 use std::env;
 use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, channel};
 use std::thread;
-use vhf::runner::{
-    Config, VHF,
-    fold::StreamFoldOp,
-    writer::{V1Writer, VHFWriter, WriteBlock},
-};
+use vhf::runner::writer::WriterBuilder;
+use vhf::runner::{Config, VHF, fold::StreamFoldOp, writer::WriteBlock};
 use vhf::{Error, Result};
 
 /// Start logging and get [vhf::runner::Config] from file and command line.
@@ -30,7 +28,10 @@ fn initialisation() -> Result<Config> {
 }
 
 /// Separate file writer into its own child thread.
-fn writer_thread(consumer: Receiver<WriteBlock>, mut file_writer: V1Writer) {
+fn writer_thread(consumer: Receiver<WriteBlock>, config: Config, time_start: Zoned) {
+    let builder: WriterBuilder<'_> = config.file_writer().unwrap();
+    let builder = builder.with_start_time(time_start);
+    let mut file_writer = builder.build();
     // try_recv will sleep when empty
     while let Ok(words) = consumer.recv() {
         file_writer.write_data(words).expect("failed to write");
@@ -42,16 +43,17 @@ fn main() -> Result<()> {
     let conf = initialisation()?;
     let board_conf = conf.build_board_config()?;
     let params = board_conf.stream_fold_parameters().clone();
-    let mut vhf = VHF::new(&conf, &params)?;
-    let time_start = vhf.start()?;
-
-    let file_writer = V1Writer::new(&conf, time_start);
     matches!(params.op, StreamFoldOp::Map);
+    assert!(conf.file_writer().is_ok());
+
+    let conf_bind = conf.clone();
+    let mut vhf = VHF::new(&conf_bind, &params)?;
+    let time_start = vhf.start()?;
 
     let (writer_send, writer_receive) = channel();
     let writer_thread = thread::Builder::new()
         .name("File Writer".to_string())
-        .spawn(move || writer_thread(writer_receive, file_writer))
+        .spawn(move || writer_thread(writer_receive, conf, time_start))
         .map_err(Error::Io)?;
 
     let vhf_iter = vhf.iter();

--- a/VHF-rs/src/bin/stream.rs
+++ b/VHF-rs/src/bin/stream.rs
@@ -40,7 +40,8 @@ fn writer_thread(consumer: Receiver<WriteBlock>, mut file_writer: V1Writer) {
 
 fn main() -> Result<()> {
     let conf = initialisation()?;
-    let params = conf.stream_fold_parameters().clone();
+    let board_conf = conf.build_board_config()?;
+    let params = board_conf.stream_fold_parameters().clone();
     let mut vhf = VHF::new(&conf, &params)?;
     let time_start = vhf.start()?;
 

--- a/VHF-rs/src/runner/config/mod.rs
+++ b/VHF-rs/src/runner/config/mod.rs
@@ -589,6 +589,11 @@ impl Configs {
             self.verbosity |= 0b100;
         }
 
+        if !self.save_to_file && strict && self.num_files != 1 {
+            log::warn!("Coercing num_files to 1 as writing to stdout found!");
+            self.num_files = 1;
+        }
+
         self.validate_config_path(strict_path)?;
 
         Ok(())

--- a/VHF-rs/src/runner/config/mod.rs
+++ b/VHF-rs/src/runner/config/mod.rs
@@ -788,7 +788,7 @@ impl Configs {
         )
     }
 
-    /// If all parameters in [self] are valid, a [BoardConfig] will be produced that fully
+    /// If all parameters passed in are valid, a [BoardConfig] will be produced that fully
     /// represents all necessary processes required to interact with VHF Board.
     pub fn build_board_config(&self) -> Result<BoardConfig> {
         // Check self.board resolves and exists. Done here because it is Configs that does not

--- a/VHF-rs/src/runner/config/mod.rs
+++ b/VHF-rs/src/runner/config/mod.rs
@@ -5,6 +5,7 @@ mod utils;
 pub(crate) mod typedef;
 
 use super::fold::StreamFold;
+use super::writer::WriterBuilder;
 use crate::{Error, Result};
 use clap::{Arg, ArgAction, ArgGroup, Command, ValueHint, value_parser};
 use configparser::ini;
@@ -799,6 +800,13 @@ impl Configs {
         };
 
         BoardConfig::new(self)
+    }
+
+    /// This is yield the WriterBuilder, which requires [WriterBuilder::with_start_time] to begin.
+    pub fn file_writer(&self) -> Result<WriterBuilder> {
+        // Default to v1arg first before breaking into individual choices through the use of
+        // [WriterBuilder::new].
+        WriterBuilder::new(self)
     }
 }
 

--- a/VHF-rs/src/runner/config/mod.rs
+++ b/VHF-rs/src/runner/config/mod.rs
@@ -781,6 +781,14 @@ impl Configs {
     /// If all parameters in [self] are valid, a [BoardConfig] will be produced that fully
     /// represents all necessary processes required to interact with VHF Board.
     pub fn build_board_config(&self) -> Result<BoardConfig> {
+        // Check self.board resolves and exists. Done here because it is Configs that does not
+        // fully assert the correctness.
+        #[cfg(not(test))]
+        if !self.board.canonicalize().map_err(Error::Io)?.exists() {
+            log::error!("Board could not be found!");
+            return Err(Error::User);
+        };
+
         BoardConfig::new(self)
     }
 }

--- a/VHF-rs/src/runner/config/mod.rs
+++ b/VHF-rs/src/runner/config/mod.rs
@@ -21,8 +21,11 @@ use utils::PythonMath;
 ///
 /// We expect to first source from the INI file, before overwriting with any command line
 /// arguments. The implementation here however does not impose any strict ordering.
-// In line with Rust's impossible to represent invalid states, the struct should only contain known
-// data.
+///
+/// While trying to be inline with Rust's impossible to represent invalid states, the struct should
+/// only contain known data, the non-finalization means that the state within the struct is an
+/// over-representation of what is alloweable. This is a superset of the valid [BoardConfig],
+/// and [WriterBuilder] states.
 #[derive(Clone, Debug)]
 pub struct Configs {
     /// For a single continuous file, this is the number of samples expected to be at least within
@@ -651,12 +654,6 @@ impl Configs {
         self.speed.base_sampling_freq() as f64 / (1. + self.skip_num as f64)
     }
 
-    /// Number of elements to read from VHF board, after board-decimation factor, before any
-    /// processing by us.
-    pub fn total_elements_to_read(&self) -> usize {
-        self.num_files * self.num_samples
-    }
-
     /// This determines the time difference the first data point of multiple files.
     pub fn file_timespan(&self) -> jiff::Span {
         // In case there are drifts...
@@ -725,11 +722,6 @@ impl Configs {
         s.join("_")
     }
 
-    /// Gets the parameters of StreamFold part of the configuration.
-    pub fn stream_fold_parameters(&self) -> &StreamFold {
-        &self.stream_fold
-    }
-
     /// Prints user-friendly string as to the configuration being used to run.
     pub fn inform_params(&self) {
         const BLUE: &str = "\x1B[34m";
@@ -784,6 +776,67 @@ impl Configs {
                 )
                 .unwrap_or_default()
         )
+    }
+
+    /// If all parameters in [self] are valid, a [BoardConfig] will be produced that fully
+    /// represents all necessary processes required to interact with VHF Board.
+    pub fn build_board_config(&self) -> Result<BoardConfig> {
+        BoardConfig::new(self)
+    }
+}
+
+/// Valid representation of board interaction along with process requirements.
+/// (These are placed together as the board has to collect more data in the event that process
+/// decimates the board's collected data.)
+pub struct BoardConfig<'a> {
+    /// For a single continuous file, this is the number of samples expected to be at least within
+    /// the file.
+    pub num_samples: &'a usize,
+    /// This is the number of continuous files is expected to run without calling USB_START_ENGINE
+    /// again.
+    pub num_files: &'a usize,
+    /// This value (known as "-s skipnum") is passed into the FPGA for decimation. Adding 1 to it
+    /// yields the decimation factor by the FPGA. Valid in 0..=65535.
+    pub skip_num: &'a u16,
+    /// This value (known as "-h" or "-l") is passed into the FPGA to operate at either 20 or 10
+    /// MHz. Defaults to High unless otherwise specified.
+    pub speed: &'a SamplingSpeed,
+
+    /// This is the dynamic gain (-g)
+    pub gain: &'a Option<u8>,
+    /// This is the hardware filter (-F) used by the FPGA for low pass filtering.
+    pub filter_const: &'a Option<u8>,
+
+    /// Runtime processing method
+    pub stream_fold: &'a StreamFold,
+
+    pub board: &'a PathBuf,
+}
+
+impl<'a> BoardConfig<'a> {
+    /// It is strongly recommended that [Configs::is_valid] is called before this point.
+    fn new(config: &'a Configs) -> Result<Self> {
+        Ok(BoardConfig {
+            num_samples: &config.num_samples,
+            num_files: &config.num_files,
+            skip_num: &config.skip_num,
+            speed: &config.speed,
+            gain: &config.gain,
+            filter_const: &config.filter_const,
+            stream_fold: &config.stream_fold,
+            board: &config.board,
+        })
+    }
+
+    /// Number of elements to read from VHF board, after board-decimation factor, before any
+    /// processing by us.
+    pub fn total_elements_to_read(&self) -> usize {
+        self.num_files * self.num_samples
+    }
+
+    /// Gets the parameters of StreamFold part of the configuration.
+    pub fn stream_fold_parameters(&self) -> &StreamFold {
+        &self.stream_fold
     }
 }
 

--- a/VHF-rs/src/runner/config/mod.rs
+++ b/VHF-rs/src/runner/config/mod.rs
@@ -594,6 +594,10 @@ impl Configs {
             self.num_files = 1;
         }
 
+        if strict && !matches!(self.encode, Encode::Binary) {
+            log::warn!("Non-binary encoding found. This setting might not be respected!");
+        }
+
         self.validate_config_path(strict_path)?;
 
         Ok(())

--- a/VHF-rs/src/runner/fold/mod.rs
+++ b/VHF-rs/src/runner/fold/mod.rs
@@ -10,16 +10,18 @@ use crate::{
 use std::{cmp::Ordering, hint::unreachable_unchecked, ops::Deref, sync::Arc};
 
 #[derive(Clone)]
-pub struct StreamFoldParameters {
+pub struct StreamFold {
     /// This the function that has to be applied to every chunked window from [super::VHF].next.
     pub func: Arc<dyn Fn(<super::VHFIter as Iterator>::Item) -> WriteBlock + Send + Sync>,
     /// This is the number of windows to step by each time prior to par_iter.
     pub step_by: usize,
     /// This is the number of windows to pad to the start.
     pub pad: usize,
+    /// This is the operation performed.
+    pub op: StreamFoldOp,
 }
 
-impl PartialEq for StreamFoldParameters {
+impl PartialEq for StreamFold {
     fn eq(&self, other: &Self) -> bool {
         std::ptr::addr_eq(Arc::as_ptr(&self.func), Arc::as_ptr(&other.func))
             && self.step_by == other.step_by
@@ -27,50 +29,38 @@ impl PartialEq for StreamFoldParameters {
     }
 }
 
-impl Eq for StreamFoldParameters {}
+impl Eq for StreamFold {}
 
 /// Determines the mode of operation on [super::VHF].next.
 #[derive(Clone, PartialEq, Eq)]
-pub enum StreamFold {
+pub enum StreamFoldOp {
     /// Identity Transform on Stream without index checking
-    None(StreamFoldParameters),
+    None,
     // Reduce,
     /// Quite literally the map in functional programming.
-    Map(StreamFoldParameters),
+    Map,
 }
 
 impl std::fmt::Debug for StreamFold {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                StreamFold::None(_) => "none",
-                StreamFold::Map(_) => "map",
-            }
-        )
+        f.debug_struct("StreamFold")
+            .field("func", &"...")
+            .field("step_by", &self.step_by)
+            .field("pad", &self.pad)
+            .field(
+                "op",
+                &match self.op {
+                    StreamFoldOp::None => "none",
+                    StreamFoldOp::Map => "map",
+                },
+            )
+            .finish()
     }
 }
 
 impl StreamFold {
-    /// Gets the number of windows to pad with at the start.
-    pub(in crate::runner) fn pad(&self) -> usize {
-        match self {
-            Self::None(x) => x.pad,
-            Self::Map(x) => x.pad,
-        }
-    }
-
-    /// Gets the number of windows to step_by each time.
-    pub(in crate::runner) fn step_by(&self) -> usize {
-        match self {
-            Self::None(x) => x.step_by,
-            Self::Map(x) => x.step_by,
-        }
-    }
-
     /// This is the Identity transform without any roll-over checking.
-    pub fn none_default() -> StreamFold {
+    pub fn none_default() -> Self {
         let identity = |(_, pages): <super::VHFIter as Iterator>::Item| {
             let data = {
                 let mut data = Vec::with_capacity(VHF_MMAP_WINDOW_LEN * MMAP_PAGE_LEN);
@@ -81,15 +71,16 @@ impl StreamFold {
             WriteBlock::new(data)
         };
 
-        StreamFold::None(StreamFoldParameters {
+        StreamFold {
             func: Arc::new(identity),
             step_by: VHF_MMAP_WINDOW_LEN,
             pad: 0,
-        })
+            op: StreamFoldOp::None,
+        }
     }
 
     //// This is the Identity transform with roll-over checking.
-    pub fn identity_default() -> StreamFold {
+    pub fn identity_default() -> Self {
         /// Offset into each window in which all pages prior can be thought of as lookbacks into
         /// previous windows.
         const PAGES_START: usize = 1;
@@ -162,11 +153,12 @@ impl StreamFold {
             result
         }
 
-        StreamFold::Map(StreamFoldParameters {
+        StreamFold {
             func: Arc::new(overlapping_identity),
             step_by: VHF_MMAP_WINDOW_LEN - PAGES_START,
             pad: PAGES_START,
-        })
+            op: StreamFoldOp::Map,
+        }
     }
 }
 

--- a/VHF-rs/src/runner/mod.rs
+++ b/VHF-rs/src/runner/mod.rs
@@ -24,6 +24,7 @@ pub mod board;
 
 /// Used in taking CLI and file configuration.
 mod config;
+pub use config::BoardConfig;
 pub use config::Configs as Config;
 
 /// Map and Reduce are subsets of Folds.  

--- a/VHF-rs/src/runner/process/mmap_reader.rs
+++ b/VHF-rs/src/runner/process/mmap_reader.rs
@@ -96,8 +96,8 @@ impl MMapReader {
             next_collect_time,
             total_pages,
             collected_pages: 0,
-            step_by: streamfold.step_by(),
-            stream_pad: streamfold.pad(),
+            step_by: streamfold.step_by,
+            stream_pad: streamfold.pad,
         })
     }
 

--- a/VHF-rs/src/runner/process/mod.rs
+++ b/VHF-rs/src/runner/process/mod.rs
@@ -107,7 +107,7 @@ impl VHF {
             let mut buffer = Deque::new();
             // Left padding is initialisation, and is thus handled in the parent.
             // Right-padding is termination, and therefore has to be handled by the child thread.
-            (0..config.stream_fold.pad())
+            (0..config.stream_fold.pad)
                 .try_for_each(|_| buffer.push_back(MmapPage::Empty))
                 .expect("Failed to push_back onto buffer.");
             Rc::new(RefCell::new(buffer))

--- a/VHF-rs/src/runner/process/mod.rs
+++ b/VHF-rs/src/runner/process/mod.rs
@@ -6,6 +6,7 @@ mod mmap_reader;
 pub(super) mod pages;
 
 use super::Config;
+use super::config::BoardConfig;
 use super::config::typedef::SamplingSpeed;
 use super::fold::StreamFold;
 use crate::{Error, Result};
@@ -35,8 +36,8 @@ const MMAP_BYTES_LEN: usize = 1 << 22;
 const DEQUE_CAP: usize = 256;
 
 /// Everything necessary to ensure the lifetime of pulling memory out from the VHF for its runtime
-pub struct VHF {
-    configuration: Box<Config>,
+pub struct VHF<'a> {
+    configuration: BoardConfig<'a>,
     handle: libc::c_int,
     raw_handle: std::fs::File,
     /// map_reader contains the thread that is responsible for pulling elements out of the MMap
@@ -64,7 +65,7 @@ pub struct VHF {
     total_pages_to_read: NonZeroUsize,
 }
 
-impl VHF {
+impl<'a> VHF<'a> {
     /// Create a new instance of VHF control. The goal of [VHF] is to create all necessary control
     /// flow to read out of Mmap and to stream in the `impl Iterator for VHF` trait.
     /// # Arguments
@@ -72,7 +73,8 @@ impl VHF {
     ///   Configuration for running VHF.
     /// - params: [StreamFold]
     ///   This is to ensure that the same parameters are being used by the driving body and [VHF].
-    pub fn new(config: &Config, params: &StreamFold) -> Result<Self> {
+    pub fn new(config: &'a Config, params: &StreamFold) -> Result<Self> {
+        let config: BoardConfig<'_> = config.build_board_config()?;
         let handle = Self::open_dev(
             config
                 .board
@@ -153,7 +155,7 @@ impl VHF {
         log::debug!("Readback buffer thread created");
 
         Ok(Self {
-            configuration: Box::new(config.clone()),
+            configuration: config,
             handle,
             raw_handle,
             map_reader: Some(map_reader),
@@ -350,7 +352,7 @@ impl VHF {
     }
 }
 
-impl Drop for VHF {
+impl Drop for VHF<'_> {
     fn drop(&mut self) {
         if !self.vhf_stop {
             log::debug!("VHF cleanup on drop has been invoked for us.");
@@ -365,7 +367,7 @@ impl Drop for VHF {
 
 pub struct VHFIter<'a> {
     /// non-iter parent
-    vhf_parent: &'a VHF,
+    vhf_parent: &'a VHF<'a>,
     /// Used to signal to [self::mmap_reader::MMapReader] has started, and to determine that child has stopped.
     engine_running: &'a Arc<AtomicBool>,
     /// Used to receive signal from [self::mmap_reader::MMapReader] that new pages have been placed into

--- a/VHF-rs/src/runner/process/test_v1_write.rs
+++ b/VHF-rs/src/runner/process/test_v1_write.rs
@@ -59,6 +59,7 @@ fn writes_correct_header() {
     let time_start = Zoned::now();
     let mut config = Configs::new(None).expect("Config struct could not be made");
     let tmp_dir = TempDir::new().expect("Could not create temp_dir");
+    config.save_to_file = true;
     config.save_dir = (*tmp_dir.path()).into();
     config.num_samples = 1 << 18;
     config.verbosity = 3;
@@ -126,6 +127,7 @@ fn creates_multiple_files() {
     let time_start = Zoned::now();
     let mut config = Configs::new(None).expect("Config struct could not be made");
     let tmp_dir = TempDir::new().expect("Could not create temp_dir");
+    config.save_to_file = true;
     config.save_dir = (*tmp_dir.path()).into();
     config.num_samples = VHF_MMAP_WINDOW_LEN * MMAP_PAGE_LEN * file_save_size;
     config.verbosity = 3;

--- a/VHF-rs/src/runner/process/test_v1_write.rs
+++ b/VHF-rs/src/runner/process/test_v1_write.rs
@@ -2,6 +2,7 @@
 
 use super::super::config::Configs;
 use super::super::fold::{StreamFold, StreamFoldOp};
+use super::super::writer::builder::Writers;
 use super::super::writer::{V1Writer, VHFWriter};
 use super::consts::MMAP_PAGE_LEN;
 use super::test_vhf::{debug_vhf_new, push_arc_pages};
@@ -63,7 +64,10 @@ fn writes_correct_header() {
     config.verbosity = 3;
     log::info!("save_dir = {:?}", &config.save_dir);
 
-    let mut writer = V1Writer::new(&config, time_start);
+    let builder = config.file_writer().unwrap();
+    matches!(builder.writer_type, Writers::V1(_));
+    let mut writer = builder.with_start_time(time_start).build();
+
     debug_vhf
         .iter()
         .step_by(params.step_by)
@@ -136,7 +140,10 @@ fn creates_multiple_files() {
 
     config.phasemeter_kwargs = phasemeter_kwargs;
 
-    let mut writer = V1Writer::new(&config, time_start);
+    let builder = config.file_writer().unwrap();
+    matches!(builder.writer_type, Writers::V1(_));
+    let mut writer = builder.with_start_time(time_start).build();
+
     debug_vhf
         .iter()
         .step_by(params.step_by)
@@ -230,7 +237,9 @@ fn creates_correct_multithreaded_files() {
     config.phasemeter_kwargs = phasemeter_kwargs;
 
     // Pull out from buffer and write to file in multithreaded
-    let mut writer = V1Writer::new(&config, time_start);
+    let builder = config.file_writer().unwrap();
+    matches!(builder.writer_type, Writers::V1(_));
+    let mut writer = builder.with_start_time(time_start).build();
     let vhf_iter = debug_vhf.iter();
     use pariter::IteratorExt;
     let body = pariter::scope(|scope| {

--- a/VHF-rs/src/runner/process/test_v1_write.rs
+++ b/VHF-rs/src/runner/process/test_v1_write.rs
@@ -3,7 +3,6 @@
 use super::super::config::Configs;
 use super::super::fold::{StreamFold, StreamFoldOp};
 use super::super::writer::builder::Writers;
-use super::super::writer::{V1Writer, VHFWriter};
 use super::consts::MMAP_PAGE_LEN;
 use super::test_vhf::{debug_vhf_new, push_arc_pages};
 use super::test_vhf_step_fold::SineArr;

--- a/VHF-rs/src/runner/process/test_v1_write.rs
+++ b/VHF-rs/src/runner/process/test_v1_write.rs
@@ -22,8 +22,11 @@ use test_log::test;
 fn writes_correct_header() {
     let debug_vhf_total_len = 4 * VHF_MMAP_WINDOW_LEN;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let (debug_vhf, dbg_vhf_sender, eng) =
-        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let debug_vhf_conf = Configs::default();
+    let (debug_vhf, dbg_vhf_sender, eng) = debug_vhf_new(
+        &debug_vhf_conf,
+        NonZeroUsize::new(debug_vhf_total_len).unwrap(),
+    );
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
     let params = StreamFold::none_default();
@@ -82,8 +85,11 @@ fn creates_multiple_files() {
     let debug_vhf_total_len = VHF_MMAP_WINDOW_LEN * scale_elements;
     log::info!("debug_vhf_total_len = {}", &debug_vhf_total_len);
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let (debug_vhf, dbg_vhf_sender, eng) =
-        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let debug_vhf_conf = Config::default();
+    let (debug_vhf, dbg_vhf_sender, eng) = debug_vhf_new(
+        &debug_vhf_conf,
+        NonZeroUsize::new(debug_vhf_total_len).unwrap(),
+    );
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
     let params = StreamFold::none_default();
@@ -159,8 +165,11 @@ fn creates_correct_multithreaded_files() {
     let debug_vhf_total_len = VHF_MMAP_WINDOW_LEN * scale_elements;
     log::info!("debug_vhf_total_len = {}", &debug_vhf_total_len);
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let (mut debug_vhf, dbg_vhf_sender, eng) =
-        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let debug_vhf_conf = Config::default();
+    let (mut debug_vhf, dbg_vhf_sender, eng) = debug_vhf_new(
+        &debug_vhf_conf,
+        NonZeroUsize::new(debug_vhf_total_len).unwrap(),
+    );
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
     let params = StreamFold::none_default();

--- a/VHF-rs/src/runner/process/test_v1_write.rs
+++ b/VHF-rs/src/runner/process/test_v1_write.rs
@@ -1,7 +1,7 @@
 //! This file is to test if [super::super::Writer] works.
 
 use super::super::config::Configs;
-use super::super::fold::StreamFold;
+use super::super::fold::{StreamFold, StreamFoldOp};
 use super::super::writer::{V1Writer, VHFWriter};
 use super::consts::MMAP_PAGE_LEN;
 use super::test_vhf::{debug_vhf_new, push_arc_pages};
@@ -26,10 +26,8 @@ fn writes_correct_header() {
         debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
-    let StreamFold::None(params) = StreamFold::none_default() else {
-        log::error!("Nonoverlapping windows are not StreamFold::None variant.");
-        panic!()
-    };
+    let params = StreamFold::none_default();
+    matches!(params.op, StreamFoldOp::None);
 
     // Define the signal we are testing for.
     let ampl = 5000f64;
@@ -88,10 +86,8 @@ fn creates_multiple_files() {
         debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
-    let StreamFold::None(params) = StreamFold::none_default() else {
-        log::error!("Nonoverlapping windows are not StreamFold::None variant.");
-        panic!()
-    };
+    let params = StreamFold::none_default();
+    matches!(params.op, StreamFoldOp::None);
 
     // Define the signal we are testing for.
     let ampl = 5000f64;
@@ -167,10 +163,8 @@ fn creates_correct_multithreaded_files() {
         debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
-    let StreamFold::None(params) = StreamFold::none_default() else {
-        log::error!("Nonoverlapping windows are not StreamFold::None variant.");
-        panic!()
-    };
+    let params = StreamFold::none_default();
+    matches!(params.op, StreamFoldOp::None);
 
     // Define the signal we are testing for.
     let ampl = 5000f64;

--- a/VHF-rs/src/runner/process/test_vhf.rs
+++ b/VHF-rs/src/runner/process/test_vhf.rs
@@ -17,13 +17,14 @@ use tempfile::{NamedTempFile, TempDir};
 use test_log::test;
 
 // Create a VHF struct with false child thread "map_reader".
-pub(super) fn debug_vhf_new(
+pub(super) fn debug_vhf_new<'a>(
+    configuration: &'a Config,
     total_to_read: NonZeroUsize,
-) -> (VHF, SyncSender<MmapPage>, Arc<AtomicBool>) {
+) -> (VHF<'a>, SyncSender<MmapPage>, Arc<AtomicBool>) {
     let tmp_dir = TempDir::new().expect("Could not create temp_dir");
     let raw_tmp_file = NamedTempFile::new_in(tmp_dir).expect("Could not create temp file");
 
-    let configuration = Config::default();
+    let configuration = configuration.build_board_config().unwrap();
     let handle = {
         use std::os::fd::AsRawFd;
         raw_tmp_file.as_raw_fd()
@@ -45,7 +46,7 @@ pub(super) fn debug_vhf_new(
 
     (
         VHF {
-            configuration: Box::new(configuration),
+            configuration,
             handle,
             raw_handle,
             map_reader: Some(map_reader),
@@ -130,8 +131,11 @@ impl ZeroArr {
 fn vhf_drops_arc() {
     let debug_vhf_total_len = 1;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let (debug_vhf, dbg_vhf_sender, eng) =
-        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let debug_vhf_conf = Config::default();
+    let (debug_vhf, dbg_vhf_sender, eng) = debug_vhf_new(
+        &debug_vhf_conf,
+        NonZeroUsize::new(debug_vhf_total_len).unwrap(),
+    );
 
     // We now add a weakpointer to the first object.
     let testing_page = Arc::new([0; MMAP_PAGE_LEN]);
@@ -203,8 +207,11 @@ impl LinearArr {
 fn next_window_linear() {
     let debug_vhf_total_len = 5;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN - 1;
-    let (debug_vhf, dbg_vhf_sender, eng) =
-        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let debug_vhf_conf = Config::default();
+    let (debug_vhf, dbg_vhf_sender, eng) = debug_vhf_new(
+        &debug_vhf_conf,
+        NonZeroUsize::new(debug_vhf_total_len).unwrap(),
+    );
 
     // Define the signal that we are testing for. (Use linear so its easier to determine.)
     let signal = LinearArr::new(total_window_len * MMAP_PAGE_LEN, eng.clone());

--- a/VHF-rs/src/runner/process/test_vhf_step_fold.rs
+++ b/VHF-rs/src/runner/process/test_vhf_step_fold.rs
@@ -4,7 +4,7 @@
 //! ```
 //! behaves to expectation.
 
-use super::super::fold::StreamFold;
+use super::super::fold::{StreamFoldOp, StreamFold};
 use super::consts::MMAP_PAGE_LEN;
 use super::test_vhf::{debug_vhf_new, push_arc_pages};
 use super::*;
@@ -94,10 +94,8 @@ fn stepped_nonoverlapping_identity_a() {
         debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
-    let StreamFold::None(params) = StreamFold::none_default() else {
-        log::error!("Nonoverlapping windows are not StreamFold::None variant.");
-        panic!()
-    };
+    let params = StreamFold::none_default();
+    matches!(params.op, StreamFoldOp::None);
 
     // Define the signal we are testing for.
     let ampl = 5000f64;
@@ -146,10 +144,8 @@ fn stepped_nonoverlapping_identity_b() {
         debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
-    let StreamFold::None(params) = StreamFold::none_default() else {
-        log::error!("Nonoverlapping windows are not StreamFold::None variant.");
-        panic!()
-    };
+    let params = StreamFold::none_default();
+    matches!(params.op, StreamFoldOp::None);
 
     // Define the signal we are testing for.
     let ampl = 5000f64;
@@ -198,10 +194,8 @@ fn stepped_nonoverlapping_identity_b() {
 /// Check that without any m-overflow, StreamFold behaves to expectation.
 #[test]
 fn stepped_overlapping_identity_a() {
-    let StreamFold::Map(params) = StreamFold::identity_default() else {
-        log::error!("Nonoverlapping windows are not StreamFold::Map variant.");
-        panic!()
-    };
+    let params = StreamFold::identity_default();
+    matches!(params.op, StreamFoldOp::Map);
 
     let debug_vhf_total_len = 4 * params.step_by;
     let total_window_len = debug_vhf_total_len + params.step_by;
@@ -266,10 +260,8 @@ fn stepped_overlapping_identity_a() {
 /// Check that with m-overflow, StreamFold behaves to expectation.
 #[test]
 fn stepped_overlapping_identity_b() {
-    let StreamFold::Map(params) = StreamFold::identity_default() else {
-        log::error!("Nonoverlapping windows are not StreamFold::Map variant.");
-        panic!()
-    };
+    let params = StreamFold::identity_default();
+    matches!(params.op, StreamFoldOp::Map);
 
     let total_window_len = params.step_by;
     let (debug_vhf, dbg_vhf_sender, eng) =

--- a/VHF-rs/src/runner/process/test_vhf_step_fold.rs
+++ b/VHF-rs/src/runner/process/test_vhf_step_fold.rs
@@ -90,8 +90,11 @@ impl Clone for SineArr {
 fn stepped_nonoverlapping_identity_a() {
     let debug_vhf_total_len = 4 * VHF_MMAP_WINDOW_LEN;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let (debug_vhf, dbg_vhf_sender, eng) =
-        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let debug_vhf_conf = Config::default();
+    let (debug_vhf, dbg_vhf_sender, eng) = debug_vhf_new(
+        &debug_vhf_conf,
+        NonZeroUsize::new(debug_vhf_total_len).unwrap(),
+    );
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
     let params = StreamFold::none_default();
@@ -140,8 +143,11 @@ fn stepped_nonoverlapping_identity_a() {
 fn stepped_nonoverlapping_identity_b() {
     let debug_vhf_total_len = 4 * VHF_MMAP_WINDOW_LEN;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let (debug_vhf, dbg_vhf_sender, eng) =
-        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let debug_vhf_conf = Config::default();
+    let (debug_vhf, dbg_vhf_sender, eng) = debug_vhf_new(
+        &debug_vhf_conf,
+        NonZeroUsize::new(debug_vhf_total_len).unwrap(),
+    );
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
     let params = StreamFold::none_default();
@@ -199,8 +205,11 @@ fn stepped_overlapping_identity_a() {
 
     let debug_vhf_total_len = 4 * params.step_by;
     let total_window_len = debug_vhf_total_len + params.step_by;
-    let (debug_vhf, dbg_vhf_sender, eng) =
-        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let debug_vhf_conf = Config::default();
+    let (debug_vhf, dbg_vhf_sender, eng) = debug_vhf_new(
+        &debug_vhf_conf,
+        NonZeroUsize::new(debug_vhf_total_len).unwrap(),
+    );
     let total_elements = total_window_len * MMAP_PAGE_LEN;
 
     // Define the signal we are testing for.
@@ -264,8 +273,11 @@ fn stepped_overlapping_identity_b() {
     matches!(params.op, StreamFoldOp::Map);
 
     let total_window_len = params.step_by;
-    let (debug_vhf, dbg_vhf_sender, eng) =
-        debug_vhf_new(NonZeroUsize::new(total_window_len).unwrap());
+    let debug_vhf_conf = Config::default();
+    let (debug_vhf, dbg_vhf_sender, eng) = debug_vhf_new(
+        &debug_vhf_conf,
+        NonZeroUsize::new(total_window_len).unwrap(),
+    );
     let total_elements = total_window_len * MMAP_PAGE_LEN;
     log::info!("total_elements = {}", total_elements);
 

--- a/VHF-rs/src/runner/writer/builder.rs
+++ b/VHF-rs/src/runner/writer/builder.rs
@@ -3,17 +3,11 @@
 //! For more details, please see [crate::runner::Configs].
 
 use super::super::{Config, config::typedef::Encode};
-use super::V1StdOut;
 use super::VHFWriter;
+use super::{V1StdOut, v1_stdout::V1StdOutArg};
 use super::{V1Writer, v1_writer::V1Arg};
 use crate::{Error, Result};
 use jiff::Zoned;
-
-#[derive(Debug, Clone)]
-pub struct V1StdOutArg<'a> {
-    pub encode: &'a Encode,
-    pub verbosity: &'a u8,
-}
 
 /// Please see [WriterBuilder].
 #[derive(Debug, Clone)]
@@ -75,7 +69,7 @@ impl<'a> WriterBuilder<'a> {
         match self.writer_type {
             Writers::V1(v1arg) => Box::new(V1Writer::new(v1arg, self.start_time.unwrap().clone())),
             Writers::V1Stdout(v1stdoutarg) => {
-                todo!()
+                Box::new(V1StdOut::new(v1stdoutarg, self.start_time.unwrap().clone()))
             }
         }
     }

--- a/VHF-rs/src/runner/writer/builder.rs
+++ b/VHF-rs/src/runner/writer/builder.rs
@@ -1,6 +1,6 @@
 //! WriterBuilder is to help determine at runtime which form of output is to be delegated to.
 //! These can be configured through the `.ini` file configuration, or with command line arguments.
-//! For more details, please see [crate::runner::Configs].
+//! For more details, please see [crate::runner::Config].
 
 use super::super::{Config, config::typedef::Encode};
 use super::VHFWriter;
@@ -24,7 +24,7 @@ pub enum Writers<'a> {
 /// might be an issue especially in the case of writing to stdout.
 pub struct WriterBuilder<'a> {
     /// This is the start time expected by all writers.  
-    /// Example: [v1_writer::V1Writer::start_time]
+    /// Example: [V1Writer::start_time]
     start_time: Option<Zoned>,
     /// The variant to be determined shall be the responsibility of [Config].
     pub writer_type: Writers<'a>,

--- a/VHF-rs/src/runner/writer/builder.rs
+++ b/VHF-rs/src/runner/writer/builder.rs
@@ -1,0 +1,67 @@
+//! WriterBuilder is to help determine at runtime which form of output is to be delegated to.
+//! These can be configured through the `.ini` file configuration, or with command line arguments.
+//! For more details, please see [crate::runner::Configs].
+
+use super::super::{Config, config::typedef::Encode};
+use super::{V1StdOut, V1Writer, VHFWriter};
+use crate::{Error, Result};
+use jiff::Zoned;
+
+#[derive(Debug, Clone)]
+pub(super) struct V1StdOutArg<'a> {
+    pub encode: &'a Encode,
+    pub verbosity: &'a u8,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct V1Arg<'a> {
+    pub num_files: &'a usize,
+    pub encode: &'a Encode,
+    pub verbosity: &'a u8,
+}
+
+/// Please see [WriterBuilder].
+#[derive(Debug, Clone)]
+pub(super) enum Writers<'a> {
+    /// This uses the same structure as V1Writer, but has the complications associated with issue
+    /// #23. [Config] should not invoke Stdout writer to the best of its ability.
+    V1Stdout(V1StdOutArg<'a>),
+    /// V1Output, but to more than 1 file with file-size guarantees.
+    V1(V1Arg<'a>),
+}
+
+/// Parameters and validation checking associated with getting the appropriate file writer
+/// Note that there is no check that logging is also writing to the same file descriptor, which
+/// might be an issue especially in the case of writing to stdout.
+pub struct WriterBuilder<'a> {
+    /// This is the start time expected by all writers.  
+    /// Example: [v1_writer::V1Writer::start_time]
+    start_time: Option<Zoned>,
+    /// The variant to be determined shall be the responsibility of [Config].
+    writer_type: Writers<'a>,
+}
+
+impl<'a> WriterBuilder<'a> {
+    /// This is for producing [Self::build], as `./stream` requires conf to determine the
+    /// file_writer type, whilst also having to time_start to already be known.
+    ///
+    /// This is currently a separate impl to separate out the logic from Config; but the end user
+    /// should only just have to pass &conf to [Config]::writer(&self, time_start) -> impl VHFWriter
+    pub(super) fn new(conf: &'a Config) -> Result<Self> {
+        todo!()
+    }
+
+    pub fn with_start_time(self, start_time: jiff::Zoned) -> Self {
+        Self {
+            start_time: Some(start_time),
+            ..self
+        }
+    }
+
+    /// Gets a FileWriter.
+    /// # Panics
+    /// If any required field has not yet been inserted.
+    pub fn build(self) -> Box<dyn VHFWriter> {
+        todo!()
+    }
+}

--- a/VHF-rs/src/runner/writer/builder.rs
+++ b/VHF-rs/src/runner/writer/builder.rs
@@ -31,24 +31,117 @@ pub struct WriterBuilder<'a> {
 }
 
 impl<'a> WriterBuilder<'a> {
+    /// Determine (and possibly reject) based on [Config], the relevant file writer to use.
+    fn writer_type(conf: &'a Config) -> Result<Writers<'a>> {
+        // Prioritize by decreasing verbosity followed by save_to_file.
+        match conf {
+            Config {
+                verbosity: 16.., ..
+            } => {
+                log::error!("verbosity >= 16 is not supported.");
+                Err(Error::User)
+            }
+            Config {
+                num_files: 0..,
+                save_to_file: true,
+                verbosity: 4..=15,
+                ..
+            } => {
+                unimplemented!("V2Writer not yet implemented.")
+            }
+            Config {
+                num_files: 0..=1,
+                save_to_file: false,
+                verbosity: 4..=7,
+                ..
+            } => {
+                unimplemented!("V2Stdout not yet implemented.")
+            }
+            Config {
+                num_files: 2..,
+                save_to_file: false,
+                verbosity: 4..=7,
+                ..
+            } => {
+                log::error!("V2 stdout conflicts with num_files > 1.");
+                Err(Error::User)
+            }
+            Config {
+                save_to_file: false,
+                verbosity: 8..,
+                ..
+            } => {
+                log::error!(
+                    "Verbosity = 8 demands Seekable on file writer, which cannot be done with Stdout. Consider writing to file instead."
+                );
+                Err(Error::User)
+            }
+            Config {
+                num_files: 0..,
+                save_to_file: true,
+                verbosity: 0..=3,
+                encode: Encode::Binary,
+                ..
+            } => Ok(Writers::V1(V1Arg {
+                num_samples: &conf.num_samples,
+                num_files: &conf.num_files,
+                encode: &conf.encode,
+                verbosity: &conf.verbosity,
+                file_timespan: Box::new(conf.file_timespan()),
+                header_details: conf.details(),
+                filename_details: conf.filename(),
+                save_dir: &conf.save_dir,
+            })),
+            Config {
+                num_files: 0..,
+                save_to_file: true,
+                verbosity: 0..=3,
+                encode: Encode::Hexadecimal | Encode::ASCII,
+                ..
+            } => {
+                log::error!("Non-binary encoding not yet implemented.");
+                Err(Error::User)
+            }
+            Config {
+                num_files: 0..=1,
+                save_to_file: false,
+                verbosity: 0..=3,
+                encode: Encode::Binary,
+                ..
+            } => Ok(Writers::V1Stdout(V1StdOutArg {
+                encode: &conf.encode,
+                verbosity: &conf.verbosity,
+                header_details: conf.details(),
+            })),
+            Config {
+                num_files: 0..=1,
+                save_to_file: false,
+                verbosity: 0..=3,
+                encode: Encode::Hexadecimal | Encode::ASCII,
+                ..
+            } => {
+                log::error!("Non-binary encoding not yet implemented.");
+                Err(Error::User)
+            }
+            Config {
+                num_files: 2..,
+                save_to_file: false,
+                verbosity: 0..=3,
+                ..
+            } => {
+                log::error!("V1 stdout conflicts with num_files > 1.");
+                Err(Error::User)
+            }
+        }
+    }
+
     /// This is for producing [Self::build], as `./stream` requires conf to determine the
     /// file_writer type, whilst also having to time_start to already be known.
     ///
     /// This is currently a separate impl to separate out the logic from Config; but the end user
     /// should only just have to pass &conf to [Config]::writer(&self, time_start) -> impl VHFWriter
     pub(crate) fn new(conf: &'a Config) -> Result<Self> {
-        // let writer_type: Writers = WriterBuilder::writer_type(conf)?;
-        // Default to V1Arg first;
-        let writer_type = Writers::V1(V1Arg {
-            num_samples: &conf.num_samples,
-            num_files: &conf.num_files,
-            encode: &conf.encode,
-            verbosity: &conf.verbosity,
-            file_timespan: Box::new(conf.file_timespan()),
-            header_details: conf.details(),
-            filename_details: conf.filename(),
-            save_dir: &conf.save_dir,
-        });
+        let writer_type: Writers = WriterBuilder::writer_type(conf)?;
         Ok(Self {
             start_time: None,
             writer_type,

--- a/VHF-rs/src/runner/writer/builder.rs
+++ b/VHF-rs/src/runner/writer/builder.rs
@@ -3,26 +3,21 @@
 //! For more details, please see [crate::runner::Configs].
 
 use super::super::{Config, config::typedef::Encode};
-use super::{V1StdOut, V1Writer, VHFWriter};
+use super::V1StdOut;
+use super::VHFWriter;
+use super::{V1Writer, v1_writer::V1Arg};
 use crate::{Error, Result};
 use jiff::Zoned;
 
 #[derive(Debug, Clone)]
-pub(super) struct V1StdOutArg<'a> {
-    pub encode: &'a Encode,
-    pub verbosity: &'a u8,
-}
-
-#[derive(Debug, Clone)]
-pub(super) struct V1Arg<'a> {
-    pub num_files: &'a usize,
+pub struct V1StdOutArg<'a> {
     pub encode: &'a Encode,
     pub verbosity: &'a u8,
 }
 
 /// Please see [WriterBuilder].
 #[derive(Debug, Clone)]
-pub(super) enum Writers<'a> {
+pub enum Writers<'a> {
     /// This uses the same structure as V1Writer, but has the complications associated with issue
     /// #23. [Config] should not invoke Stdout writer to the best of its ability.
     V1Stdout(V1StdOutArg<'a>),
@@ -38,7 +33,7 @@ pub struct WriterBuilder<'a> {
     /// Example: [v1_writer::V1Writer::start_time]
     start_time: Option<Zoned>,
     /// The variant to be determined shall be the responsibility of [Config].
-    writer_type: Writers<'a>,
+    pub writer_type: Writers<'a>,
 }
 
 impl<'a> WriterBuilder<'a> {
@@ -47,8 +42,23 @@ impl<'a> WriterBuilder<'a> {
     ///
     /// This is currently a separate impl to separate out the logic from Config; but the end user
     /// should only just have to pass &conf to [Config]::writer(&self, time_start) -> impl VHFWriter
-    pub(super) fn new(conf: &'a Config) -> Result<Self> {
-        todo!()
+    pub(crate) fn new(conf: &'a Config) -> Result<Self> {
+        // let writer_type: Writers = WriterBuilder::writer_type(conf)?;
+        // Default to V1Arg first;
+        let writer_type = Writers::V1(V1Arg {
+            num_samples: &conf.num_samples,
+            num_files: &conf.num_files,
+            encode: &conf.encode,
+            verbosity: &conf.verbosity,
+            file_timespan: Box::new(conf.file_timespan()),
+            header_details: conf.details(),
+            filename_details: conf.filename(),
+            save_dir: &conf.save_dir,
+        });
+        Ok(Self {
+            start_time: None,
+            writer_type,
+        })
     }
 
     pub fn with_start_time(self, start_time: jiff::Zoned) -> Self {
@@ -62,6 +72,11 @@ impl<'a> WriterBuilder<'a> {
     /// # Panics
     /// If any required field has not yet been inserted.
     pub fn build(self) -> Box<dyn VHFWriter> {
-        todo!()
+        match self.writer_type {
+            Writers::V1(v1arg) => Box::new(V1Writer::new(v1arg, self.start_time.unwrap().clone())),
+            Writers::V1Stdout(v1stdoutarg) => {
+                todo!()
+            }
+        }
     }
 }

--- a/VHF-rs/src/runner/writer/mod.rs
+++ b/VHF-rs/src/runner/writer/mod.rs
@@ -1,4 +1,4 @@
-mod builder;
+pub(super) mod builder;
 pub use builder::WriterBuilder;
 // mod netcdf_writer;
 mod v1_stdout;
@@ -10,7 +10,6 @@ use v1_writer::V1_MAGIC_HEADER;
 pub use v1_writer::V1Writer;
 
 use super::super::types::RawVHFWord;
-use super::Config;
 use crate::Result;
 
 /// In the event that the [VHFWriter] receives less than this amount of data, no file will be

--- a/VHF-rs/src/runner/writer/mod.rs
+++ b/VHF-rs/src/runner/writer/mod.rs
@@ -96,13 +96,6 @@ impl WriteBlock {
 /// file of desired type. The struct will transparently handle writing into a new file, with
 /// appropriate header information.
 pub trait VHFWriter {
-    /// Creates an object that allows for writing of data processed out of [super::process::VHF].
-    /// Whilst still working out if [crate::runner::Config] contains enough information about the
-    /// runtime, the `main()` function should instead be responsible for determining the time by
-    /// which the first data point is being written to file. This means that data points being
-    /// dropped in processing should be accounted for.
-    fn new(config: &Config, start_time: jiff::Zoned) -> Self;
-
     /// Processed or otherwise, write to the intended file the data portion.
     /// This method also silently handles dealing with any header manipulation that occurs from
     /// writing data if relevant

--- a/VHF-rs/src/runner/writer/mod.rs
+++ b/VHF-rs/src/runner/writer/mod.rs
@@ -1,9 +1,13 @@
 // mod netcdf_writer;
+mod v1_stdout;
 mod v1_writer;
 // mod v2_writer;
 
 use super::super::types::RawVHFWord;
 use crate::{Result, runner::Config};
+
+pub use v1_stdout::V1StdOut;
+use v1_writer::V1_MAGIC_HEADER;
 pub use v1_writer::V1Writer;
 
 /// In the event that the [VHFWriter] receives less than this amount of data, no file will be

--- a/VHF-rs/src/runner/writer/mod.rs
+++ b/VHF-rs/src/runner/writer/mod.rs
@@ -1,14 +1,17 @@
+mod builder;
+pub use builder::WriterBuilder;
 // mod netcdf_writer;
 mod v1_stdout;
 mod v1_writer;
 // mod v2_writer;
 
-use super::super::types::RawVHFWord;
-use crate::{Result, runner::Config};
-
 pub use v1_stdout::V1StdOut;
 use v1_writer::V1_MAGIC_HEADER;
 pub use v1_writer::V1Writer;
+
+use super::super::types::RawVHFWord;
+use super::Config;
+use crate::Result;
 
 /// In the event that the [VHFWriter] receives less than this amount of data, no file will be
 /// written. This is particularly necessary for when a trailing amount of data is created but just

--- a/VHF-rs/src/runner/writer/v1_spec.md
+++ b/VHF-rs/src/runner/writer/v1_spec.md
@@ -1,0 +1,35 @@
+# VHF V1 (Binary) File Specification
+
+## Scope
+
+* Specify the *VHF* `.bin` (V1) file structure.
+
+## Definitions
+
+* `Word`: 8-consecutive bytes.
+
+## Specification
+
+1. The first word SHALL be written in little-endian format.
+2. The file MUST be an integer multiple of 8 bytes. If this condition is not
+   met, it is likely a syscall writing to the file was interrupted. User
+   discretion whether the file MAY be read is not outside the scope of this
+   document.
+3. The first word `w0` (located from the 0th byte of the file) shall conform to
+   the format: `0x123456abcdef0000`, where the two least significant bytes
+   (`0000`) MAY vary. The two least significant bytes SHOULD be used to
+   determined the total header length `hl`, inclusive of `w0`.  
+   (Number of words read: 1).
+4. The next `hl - 1` words SHALL be read to complete the header. These words
+   SHOULD be UTF-8 decoded to determine the condition which the file was
+   written. No character in all `hl - 1` words SHALL be undecodable by UTF-8,
+   i.e.: Any space after text before the end of a word MUST be zero-ed.  
+   (Number of words read: `hl`)
+5. If timing information is present within the header following the string `#
+   recording start: `, it SHALL denote the timing information associated to the
+   word located at the (8*`hl`)-th byte. If timezone information is not
+   specified, it SHALL be assumed to be in local time where the recording
+   occurred.
+6. All data following the header SHALL consist of consecutive words. All words
+   MUST be in little-endian format. Refer to the binary data specification on
+   how to parse this data.

--- a/VHF-rs/src/runner/writer/v1_stdout.rs
+++ b/VHF-rs/src/runner/writer/v1_stdout.rs
@@ -22,19 +22,6 @@ pub struct V1StdOut {
 }
 
 impl VHFWriter for V1StdOut {
-    /// # Silent errors
-    /// Does not respect if encode is not Binary.
-    fn new(config: &crate::runner::Config, start_time: jiff::Zoned) -> Self {
-        Self {
-            start_time,
-            verbosity: config.verbosity,
-            header_details: config.details(),
-            encode: config.encode,
-            stdout: BufWriter::new(std::io::stdout()),
-            has_written: AtomicBool::new(false),
-        }
-    }
-
     fn close(&mut self) -> Result<()> {
         use std::io::Write;
         self.stdout.flush().map_err(Error::Io)?;
@@ -56,6 +43,25 @@ impl VHFWriter for V1StdOut {
 }
 
 impl V1StdOut {
+    /// Creates an object that allows for writing of data processed out of [super::process::VHF].
+    /// Whilst still working out if [crate::runner::Config] contains enough information about the
+    /// runtime, the `main()` function should instead be responsible for determining the time by
+    /// which the first data point is being written to file. This means that data points being
+    /// dropped in processing should be accounted for.
+    ///
+    /// # Silent errors
+    /// Does not respect if encode is not Binary.
+    pub fn new(config: &crate::runner::Config, start_time: jiff::Zoned) -> Self {
+        Self {
+            start_time,
+            verbosity: config.verbosity,
+            header_details: config.details(),
+            encode: config.encode,
+            stdout: BufWriter::new(std::io::stdout()),
+            has_written: AtomicBool::new(false),
+        }
+    }
+
     fn write_header(&mut self) -> Result<()> {
         // Early exit
         if self.verbosity == 0 {

--- a/VHF-rs/src/runner/writer/v1_stdout.rs
+++ b/VHF-rs/src/runner/writer/v1_stdout.rs
@@ -1,0 +1,96 @@
+//! Writer method meant to be as identical as possible to the original C file writer, but designed
+//! specifically for stdout writing.
+
+use super::{V1_MAGIC_HEADER, VHFWriter};
+use crate::{Error, Result};
+use jiff::Zoned;
+use std::{
+    io::{BufWriter, Stdout},
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+pub struct V1StdOut {
+    /// Timestamp of the first file's first datapoint.
+    start_time: Zoned,
+    verbosity: u8,
+    header_details: String,
+    stdout: BufWriter<Stdout>,
+    has_written: AtomicBool,
+}
+
+impl VHFWriter for V1StdOut {
+    fn new(config: &crate::runner::Config, start_time: jiff::Zoned) -> Self {
+        Self {
+            start_time,
+            verbosity: config.verbosity,
+            header_details: config.details(),
+            stdout: BufWriter::new(std::io::stdout()),
+            has_written: AtomicBool::new(false),
+        }
+    }
+
+    fn close(&mut self) -> Result<()> {
+        use std::io::Write;
+        self.stdout.flush().map_err(Error::Io)?;
+        Ok(())
+    }
+
+    fn write_data(&mut self, words: super::WriteBlock) -> Result<()> {
+        if !self.has_written.load(Ordering::Acquire) {
+            self.write_header()?;
+        }
+
+        use byteorder::{LittleEndian, WriteBytesExt};
+        words
+            .data
+            .into_iter()
+            .try_for_each(move |word| self.stdout.write_u64::<LittleEndian>(word))
+            .map_err(Error::Io)
+    }
+}
+
+impl V1StdOut {
+    fn write_header(&mut self) -> Result<()> {
+        // Early exit
+        if self.verbosity == 0 {
+            return Ok(());
+        }
+
+        let mut header = String::new();
+        if self.verbosity & 1 != 0 {
+            // Command Line
+            header.extend(["# command line: ", self.header_details.as_str(), "\n"]);
+        }
+
+        if self.verbosity & 2 != 0 {
+            // Time start
+            header.extend([
+                "# recording start: ".to_string(),
+                self.start_time.strftime("%FT%T%z").to_string(),
+                "\n".to_string(),
+            ]);
+        }
+        // + 1 to include the magic mask length
+        let header_len = header.len().div_ceil(8) + 1;
+        if header_len > 0xffff {
+            log::error!("Too much data written into header!");
+            return Err(Error::ExcessData);
+        };
+
+        use byteorder::{LittleEndian, WriteBytesExt};
+        use std::io::Write;
+        let header_first = V1_MAGIC_HEADER | (header_len as u64);
+        self.stdout
+            .write_u64::<LittleEndian>(header_first)
+            .map_err(Error::Io)?;
+        self.stdout
+            .write_all(header.as_bytes())
+            .map_err(Error::Io)?;
+        let pad = header.len().div_ceil(8) * 8 - header.len();
+        self.stdout.write(&vec![0u8; pad]).map_err(Error::Io)?;
+
+        self.has_written.store(true, Ordering::Release);
+
+        Ok(())
+    }
+}

--- a/VHF-rs/src/runner/writer/v1_stdout.rs
+++ b/VHF-rs/src/runner/writer/v1_stdout.rs
@@ -1,6 +1,7 @@
 //! Writer method meant to be as identical as possible to the original C file writer, but designed
 //! specifically for stdout writing.
 
+use super::super::config::typedef::Encode;
 use super::{V1_MAGIC_HEADER, VHFWriter};
 use crate::{Error, Result};
 use jiff::Zoned;
@@ -14,16 +15,21 @@ pub struct V1StdOut {
     start_time: Zoned,
     verbosity: u8,
     header_details: String,
+    #[allow(dead_code)]
+    encode: Encode,
     stdout: BufWriter<Stdout>,
     has_written: AtomicBool,
 }
 
 impl VHFWriter for V1StdOut {
+    /// # Silent errors
+    /// Does not respect if encode is not Binary.
     fn new(config: &crate::runner::Config, start_time: jiff::Zoned) -> Self {
         Self {
             start_time,
             verbosity: config.verbosity,
             header_details: config.details(),
+            encode: config.encode,
             stdout: BufWriter::new(std::io::stdout()),
             has_written: AtomicBool::new(false),
         }

--- a/VHF-rs/src/runner/writer/v1_stdout.rs
+++ b/VHF-rs/src/runner/writer/v1_stdout.rs
@@ -52,12 +52,12 @@ impl V1StdOut {
     ///
     /// # Silent errors
     /// Does not respect if encode is not Binary.
-    pub fn new(config: &crate::runner::Config, start_time: jiff::Zoned) -> Self {
+    pub fn new(config: V1StdOutArg, start_time: jiff::Zoned) -> Self {
         Self {
             start_time,
-            verbosity: config.verbosity,
-            header_details: config.details(),
-            encode: config.encode,
+            verbosity: *config.verbosity,
+            header_details: config.header_details,
+            encode: *config.encode,
             stdout: BufWriter::new(std::io::stdout()),
             has_written: AtomicBool::new(false),
         }
@@ -106,4 +106,11 @@ impl V1StdOut {
 
         Ok(())
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct V1StdOutArg<'a> {
+    pub encode: &'a Encode,
+    pub verbosity: &'a u8,
+    pub header_details: String,
 }

--- a/VHF-rs/src/runner/writer/v1_stdout.rs
+++ b/VHF-rs/src/runner/writer/v1_stdout.rs
@@ -10,6 +10,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
+/// This has not been well-tested! Please consider using [super::V1Writer]!
 pub struct V1StdOut {
     /// Timestamp of the first file's first datapoint.
     start_time: Zoned,

--- a/VHF-rs/src/runner/writer/v1_stdout.rs
+++ b/VHF-rs/src/runner/writer/v1_stdout.rs
@@ -44,11 +44,11 @@ impl VHFWriter for V1StdOut {
 }
 
 impl V1StdOut {
-    /// Creates an object that allows for writing of data processed out of [super::process::VHF].
-    /// Whilst still working out if [crate::runner::Config] contains enough information about the
-    /// runtime, the `main()` function should instead be responsible for determining the time by
-    /// which the first data point is being written to file. This means that data points being
-    /// dropped in processing should be accounted for.
+    /// Creates an object that allows for writing of data processed out of
+    /// [crate::runner::process::VHF]. Whilst still working out if [crate::runner::Config] contains
+    /// enough information about the runtime, the `main()` function should instead be responsible
+    /// for determining the time by which the first data point is being written to file. This means
+    /// that data points being dropped in processing should be accounted for.
     ///
     /// # Silent errors
     /// Does not respect if encode is not Binary.

--- a/VHF-rs/src/runner/writer/v1_writer.rs
+++ b/VHF-rs/src/runner/writer/v1_writer.rs
@@ -17,7 +17,7 @@ use std::{
     thread,
 };
 
-const V1_MAGIC_HEADER: u64 = 0x123456ABCDEF0000;
+pub(super) const V1_MAGIC_HEADER: u64 = 0x123456ABCDEF0000;
 
 pub struct V1Writer {
     /// Timestamp of the first file's first datapoint.

--- a/VHF-rs/src/runner/writer/v1_writer.rs
+++ b/VHF-rs/src/runner/writer/v1_writer.rs
@@ -2,7 +2,7 @@
 
 use super::super::config::typedef::Encode;
 use super::{FILE_LAZY_LEN, VHFWriter};
-use crate::{Error, Result, runner::Config, types::RawVHFWord};
+use crate::{Error, Result, types::RawVHFWord};
 #[cfg(not(test))]
 use jiff::SignedDuration;
 use jiff::{Span, Zoned};
@@ -10,7 +10,7 @@ use std::{
     fmt::Debug,
     fs::{File, OpenOptions},
     io::BufWriter,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -84,6 +84,18 @@ impl VHFWriter for V1Writer {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct V1Arg<'a> {
+    pub num_samples: &'a usize,
+    pub num_files: &'a usize,
+    pub encode: &'a Encode,
+    pub verbosity: &'a u8,
+    pub file_timespan: Box<Span>,
+    pub header_details: String,
+    pub filename_details: String,
+    pub save_dir: &'a Path,
+}
+
 impl V1Writer {
     /// Creates an object that allows for writing of data processed out of [super::process::VHF].
     /// Whilst still working out if [crate::runner::Config] contains enough information about the
@@ -93,22 +105,22 @@ impl V1Writer {
     ///
     /// # Silent errors
     /// Does not respect if encode is not Binary.
-    pub fn new(config: &Config, start_time: jiff::Zoned) -> Self {
+    pub fn new(config: V1Arg, start_time: jiff::Zoned) -> Self {
         Self {
             start_time,
-            num_files: config.num_files,
+            num_files: *config.num_files,
             num_files_so_far: AtomicUsize::new(0),
-            time_between_files: config.file_timespan(),
-            num_elements_per_file: config.num_samples,
+            time_between_files: *config.file_timespan,
+            num_elements_per_file: *config.num_samples,
             num_elements_written: AtomicUsize::new(0),
-            verbosity: config.verbosity,
-            header_details: config.details(),
-            filename_details: config.filename(),
-            encode: config.encode,
+            verbosity: *config.verbosity,
+            header_details: config.header_details.to_string(),
+            filename_details: config.filename_details.to_string(),
+            encode: *config.encode,
             elements_to_write: Arc::new(Mutex::new(Vec::with_capacity(
-                FILE_LAZY_LEN.min(config.num_samples),
+                FILE_LAZY_LEN.min(*config.num_samples),
             ))),
-            file_dir: config.save_dir.clone(),
+            file_dir: config.save_dir.to_path_buf(),
             current_file_handle: Arc::new(Mutex::new(None)),
         }
     }

--- a/VHF-rs/src/runner/writer/v1_writer.rs
+++ b/VHF-rs/src/runner/writer/v1_writer.rs
@@ -43,28 +43,6 @@ pub struct V1Writer {
 }
 
 impl VHFWriter for V1Writer {
-    /// # Silent errors
-    /// Does not respect if encode is not Binary.
-    fn new(config: &Config, start_time: jiff::Zoned) -> Self {
-        Self {
-            start_time,
-            num_files: config.num_files,
-            num_files_so_far: AtomicUsize::new(0),
-            time_between_files: config.file_timespan(),
-            num_elements_per_file: config.num_samples,
-            num_elements_written: AtomicUsize::new(0),
-            verbosity: config.verbosity,
-            header_details: config.details(),
-            filename_details: config.filename(),
-            encode: config.encode,
-            elements_to_write: Arc::new(Mutex::new(Vec::with_capacity(
-                FILE_LAZY_LEN.min(config.num_samples),
-            ))),
-            file_dir: config.save_dir.clone(),
-            current_file_handle: Arc::new(Mutex::new(None)),
-        }
-    }
-
     /// Push [super::WriteBlock] onto file.
     fn write_data(&mut self, mut words: super::WriteBlock) -> Result<()> {
         let data: &mut Vec<_> = &mut words.data;
@@ -107,6 +85,34 @@ impl VHFWriter for V1Writer {
 }
 
 impl V1Writer {
+    /// Creates an object that allows for writing of data processed out of [super::process::VHF].
+    /// Whilst still working out if [crate::runner::Config] contains enough information about the
+    /// runtime, the `main()` function should instead be responsible for determining the time by
+    /// which the first data point is being written to file. This means that data points being
+    /// dropped in processing should be accounted for.
+    ///
+    /// # Silent errors
+    /// Does not respect if encode is not Binary.
+    pub fn new(config: &Config, start_time: jiff::Zoned) -> Self {
+        Self {
+            start_time,
+            num_files: config.num_files,
+            num_files_so_far: AtomicUsize::new(0),
+            time_between_files: config.file_timespan(),
+            num_elements_per_file: config.num_samples,
+            num_elements_written: AtomicUsize::new(0),
+            verbosity: config.verbosity,
+            header_details: config.details(),
+            filename_details: config.filename(),
+            encode: config.encode,
+            elements_to_write: Arc::new(Mutex::new(Vec::with_capacity(
+                FILE_LAZY_LEN.min(config.num_samples),
+            ))),
+            file_dir: config.save_dir.clone(),
+            current_file_handle: Arc::new(Mutex::new(None)),
+        }
+    }
+
     /// Tries to open a file in the specified location with the required name. Fails if file
     /// already exists.
     fn open_file(&mut self) -> Result<BufWriter<File>> {

--- a/VHF-rs/src/runner/writer/v1_writer.rs
+++ b/VHF-rs/src/runner/writer/v1_writer.rs
@@ -97,11 +97,11 @@ pub struct V1Arg<'a> {
 }
 
 impl V1Writer {
-    /// Creates an object that allows for writing of data processed out of [super::process::VHF].
-    /// Whilst still working out if [crate::runner::Config] contains enough information about the
-    /// runtime, the `main()` function should instead be responsible for determining the time by
-    /// which the first data point is being written to file. This means that data points being
-    /// dropped in processing should be accounted for.
+    /// Creates an object that allows for writing of data processed out of
+    /// [crate::runner::process::VHF]. Whilst still working out if [crate::runner::Config] contains
+    /// enough information about the runtime, the `main()` function should instead be responsible
+    /// for determining the time by which the first data point is being written to file. This means
+    /// that data points being dropped in processing should be accounted for.
     ///
     /// # Silent errors
     /// Does not respect if encode is not Binary.

--- a/VHF-rs/src/runner/writer/v1_writer.rs
+++ b/VHF-rs/src/runner/writer/v1_writer.rs
@@ -1,5 +1,6 @@
 //! Writer method meant to be as identical as possible to the original C file writer.
 
+use super::super::config::typedef::Encode;
 use super::{FILE_LAZY_LEN, VHFWriter};
 use crate::{Error, Result, runner::Config, types::RawVHFWord};
 #[cfg(not(test))]
@@ -33,6 +34,8 @@ pub struct V1Writer {
     verbosity: u8,
     header_details: String,
     filename_details: String,
+    #[allow(dead_code)]
+    encode: Encode,
     /// Avoid writing to a file until we exceed some amount.
     elements_to_write: Arc<Mutex<Vec<RawVHFWord>>>,
     file_dir: PathBuf,
@@ -40,6 +43,8 @@ pub struct V1Writer {
 }
 
 impl VHFWriter for V1Writer {
+    /// # Silent errors
+    /// Does not respect if encode is not Binary.
     fn new(config: &Config, start_time: jiff::Zoned) -> Self {
         Self {
             start_time,
@@ -51,6 +56,7 @@ impl VHFWriter for V1Writer {
             verbosity: config.verbosity,
             header_details: config.details(),
             filename_details: config.filename(),
+            encode: config.encode,
             elements_to_write: Arc::new(Mutex::new(Vec::with_capacity(
                 FILE_LAZY_LEN.min(config.num_samples),
             ))),

--- a/VHF/parse.py
+++ b/VHF/parse.py
@@ -727,21 +727,11 @@ class VHFparser:
             raise ValueError(
                 "Buffer does not conform to header expectations.")
 
-        # in accordance with convert_bin_to_text.c
-        header_count_b = (int.from_bytes(header, "little") & 0xFFFF) - 1
-        # in teststream.c (SVN v17), 1 + i lines(8 bytes) were written (see
-        # line 353), where i was (magic mask + 1). we note that due to improper
-        # null termination of headerbuffer (in line 352) meant that
-        # teststream.c was reading beyond buffer, which was not guaranteed to
-        # be all 0s. Nonetheless, consume it as header in accordance with
-        # masked magic number and dump away. As such, stripping supposed 0s are
-        # ok.
-        # -----
-        # + 1 to read one more byte than spec (convert_bin_to_text.c)
+        header_count_b = (int.from_bytes(header, "little") & 0xFFFF)
         self._bytes_per_word = BinaryVHFTrace.bytes_per_word
-        header_count = (header_count_b+1) * self._bytes_per_word
+        header_count = (header_count_b) * self._bytes_per_word
         self._num_head_bytes += header_count  # this is the claimed headersize
-        self.headerraw: bytes = buffer.read(header_count-8)  # read continues stream position
+        self.headerraw: bytes = buffer.read(header_count - self._bytes_per_word)  # read continues stream position
         self.headerraw = self.headerraw.rstrip(b"\x00")
         self.parse_header(self.headerraw)
 

--- a/log4rs.yml
+++ b/log4rs.yml
@@ -1,13 +1,13 @@
 root:
   level: info
   appenders:
-    - stdout
+    - stderr
     - file
 
 appenders:
-  stdout:
+  stderr:
     kind: console
-    target: stdout
+    target: stderr
     filters:
       - kind: threshold
         level: info


### PR DESCRIPTION
This was written in process of trying to see the necessary control flow to go into v2.

Note that if any in-flight processing that either skips/modifies phase values must not
be written into the v1 file format, as the headers do not support this information.